### PR TITLE
Add April 22 share-with-control blog posts

### DIFF
--- a/_posts/en/2026-04-22-quando-un-medico-ti-chiede-un-referto-come-condividerlo-senza-usare-whatsapp.md
+++ b/_posts/en/2026-04-22-quando-un-medico-ti-chiede-un-referto-come-condividerlo-senza-usare-whatsapp.md
@@ -12,228 +12,263 @@ classes: wide
 ---
 
 ![image-center](assets/images/ancona_view_belvedere_nord.webp){: .align-center}
-**When you need to send a medical report quickly, the job is not only sending it. It is finding it again, understanding it, and knowing who received it.**
+**When a doctor asks for a report, the hard part is rarely hitting "send". The hard part is sending the right file, with the right context, without creating new confusion for the next visit.**
 
-## WhatsApp feels fast. It does not always feel clear.
+## The real problem starts after the message is sent
 
-When a doctor asks for a report, everything often happens quickly.
+It usually happens in a hurry.
 
-A message arrives. A call comes in. Or an appointment ends with a simple request:
+You are leaving a visit. A doctor says, "Please send me the blood tests as well." Or your phone rings and the clinic asks for the last ultrasound before they confirm the appointment.
 
-> "Can you also send me the previous test results?"
+Most people react the same way:
 
-At that point, most people do the same thing. They open WhatsApp, look for the file, or a photo, or a screenshot, and send it.
+- open WhatsApp
+- scroll through old messages
+- look for a PDF, a photo, or a screenshot
+- send whatever seems right
 
-It feels like the fastest path. In the short term, it often is.
+In that moment, chat feels efficient. The doctor already uses it. The contact is already there. It takes seconds.
 
-The problem comes afterwards.
+But healthcare work is not finished when the file leaves your phone.
 
-Where did that report end up? Did you send the right file? Was it readable? Was it the latest version? Did you also send it to another doctor? If you need it again next month, will you be able to find it?
+The next questions arrive immediately:
 
-The point is not that WhatsApp is "wrong". The point is that a chat thread was never designed to manage important health documents over time.
+- Was that the latest report?
+- Was it the PDF or just a photo of the paper copy?
+- Did you also send it to the other specialist?
+- Will you find it again next month?
+- If someone else in the family needs to help, will they understand what was sent?
 
-When health information is involved, sharing should not only be fast. It should also be clear, organised, and under control.
+This is why WhatsApp is not really the problem. The problem is using a conversation thread as if it were a document workflow.
 
-## Why chat feels convenient
+## Why WhatsApp feels good enough until it does not
 
-WhatsApp is already there.
+WhatsApp solves one narrow problem very well: quick coordination.
 
-You use it every day. You already have the doctor's number, the family member's number, the caregiver's number, or the clinic contact. Taking a photo and sending it takes only a few seconds, so many families naturally use chat for reports, prescriptions, discharge letters, images, and treatment plans.
+It is perfect for:
 
-The appeal is simple:
+- "I am running ten minutes late"
+- "The doctor moved the appointment"
+- "Can you call me back?"
 
-- no new tool to learn
-- the file can be sent immediately
-- the doctor receives it in seconds
+It is much weaker when the task is:
 
-If the need feels urgent, that can seem good enough.
+- recovering the correct clinical document
+- sharing only what matters
+- keeping a record of what was shared
+- repeating the same operation calmly later
 
-But health documents rarely matter only once. They often need to be found again, compared, resent, or shared more selectively later.
+Health documents are not ordinary attachments. They often need to be reviewed again, compared with older exams, re-shared with another clinician, or kept available for a family member who is helping with care.
 
-That is where chat starts to show its limits.
+That means the quality of the sharing process matters almost as much as the speed.
 
-## The issue is not sending a file. It is managing what happens next.
+## What usually goes wrong in chat-based sharing
 
-Once a report is shared in a chat, it quickly loses context.
+The failure mode is rarely dramatic. It is usually mundane, and that is exactly why it keeps happening.
 
-The same thread contains:
+### 1. The file loses context immediately
 
-- practical messages
+A report lands in the middle of a thread full of other material:
+
+- appointment messages
 - voice notes
-- quick questions
-- other attachments
-- reminders
-- replies from different days or weeks
+- practical questions
+- greetings
+- unrelated attachments
 
-After a short time, finding one important document becomes harder than expected.
+Two weeks later, no one remembers whether that PDF was the blood test, the discharge summary, or the imaging report.
 
-In many families, the same record is also sent multiple times:
+### 2. Different versions start circulating
 
-- to a GP
-- to a specialist
-- to a relative helping with care
-- to the person handling the booking
+One person sends the PDF from the patient portal. Another forwards a phone photo. A family member sends the same exam again but with a different filename. Soon the group is no longer discussing a document. It is discussing which document is the right one.
 
-The result is familiar: duplicate versions, low-quality photos, files spread across different chats, and no clear sense of what was shared with whom.
+### 3. Urgency pushes people to overshare
 
-The most common risk is not technical. It is practical.
+When a doctor asks for one report, families often send five. It feels safer in the moment, but it creates noise for the clinician and more uncertainty for the person sending.
 
-You lose time.
+Good sharing is not "everything, just in case." Good sharing is the minimum set of files needed to move the clinical conversation forward.
 
-You create confusion.
+### 4. Nobody can reconstruct what happened later
 
-And it happens exactly when clarity matters most.
+This is the most underestimated problem.
 
-## What makes chat-based sharing fragile
+At the next visit someone asks:
 
-WhatsApp works well for quick coordination.
+> "Did we already send the cardiology report to the specialist?"
 
-A health report needs a little more structure.
+If the answer lives inside three chat threads and one family member's memory, the system is already fragile.
 
-### 1. The document gets buried in the conversation
+## Privacy in everyday life is not a slogan. It is control.
 
-An important file ends up mixed with dozens of unrelated messages. A few days later, recovering it depends on memory and patience.
+People often hear "privacy" and think of regulations, settings, or abstract security language.
 
-### 2. It is not always obvious which version you sent
+In real family healthcare work, privacy is more concrete than that.
 
-Did you send the PDF downloaded from the portal or a photo of the paper copy? Did you send the latest test or the one from last year? In chat, these mistakes are easier than they seem.
+Privacy means:
 
-### 3. There is no continuity
+- sharing one report without exposing the entire history
+- keeping one family member's records separate from another's
+- knowing who received what
+- avoiding the accidental habit of sending everything to everyone
 
-Health documents rarely matter only once. They matter at the next visit, with the next specialist, during a follow-up, or when another family member needs context. If the file lives in a chat, each new share often starts from scratch.
+This is why chat feels uncomfortable as a long-term method, even when people trust the person on the other end. The issue is not only secrecy. It is control and proportion.
 
-### 4. It is easier to overshare than to share well
+A clinical document should be easy to share on purpose, not easy to scatter by habit.
 
-When you are rushed, it is tempting to send a whole stack of files "just in case". But the more you send without structure, the more noise you create for the person reading them.
+## A better workflow when a doctor asks for a report
 
-## In real life, privacy means control
+The alternative is not bureaucracy. The alternative is a cleaner routine.
 
-Health privacy is often discussed in abstract terms.
+Here is what a strong sharing workflow looks like in practice.
 
-For families, it usually comes down to something much more practical:
+### 1. Start from a single archive, not from memory
 
-knowing which documents you are sharing, with whom, and for what reason.
+The first step should never be, "Where did I put that file?"
 
-This is not only about technical protection. It is about practical control.
+It should be, "Open the archive, search the report, verify the date."
 
-For example:
+That shift matters because it removes guesswork. You are no longer searching across:
 
-- you may want to share one report without resending an entire medical history
-- you may want to send a document to a doctor without reviving old files inside a chat thread
-- you may need to keep one person's records separate from another family member's
-- you may want to quickly understand what has already been shared
+- chat threads
+- email inboxes
+- local downloads
+- phone galleries
+- paper documents photographed months ago
 
-When sharing always happens through different chat threads, that control weakens.
+You start from a known place. That alone reduces stress.
 
-Not because people are careless, but because chat is not designed to be a clear, reliable home for shared health documents.
+### 2. Confirm the document before you share it
 
-## What to do instead when a doctor asks for a report
+Before sending anything, check three basics:
 
-The alternative is not to make life more complicated.
+- Is this the correct patient?
+- Is this the latest relevant version?
+- Is the file readable without explanation?
 
-The alternative is to make sharing simpler and clearer.
+These checks take less than a minute and prevent the most common wasteful loop in healthcare messaging:
 
-A useful routine can look like this.
+1. send quickly
+2. receive "I cannot read it" or "I meant the previous one"
+3. send again
+4. lose confidence in the process
 
-### 1. Start from one archive
+### 3. Share the smallest useful set
 
-The first benefit of keeping documents in one place is that you no longer need to remember whether the file was:
+If the doctor asks for one report, start with that report.
 
-- in chat
-- in email
-- in downloads
-- in your phone gallery
-- in an old paper folder you photographed months ago
+If a second document helps with context, add it deliberately. For example:
 
-You search once. You find the right file. You start from there.
+- the requested blood test
+- the previous comparison test
+- a short note saying why the clinician is receiving it
 
-### 2. Check that it is readable and current
+That is very different from throwing ten files into a chat and hoping the right one stands out.
 
-Before sharing, verify two simple things:
+### 4. Make the share legible to the receiver
 
-- is this the correct document?
-- is it easy to read?
+A strong share is not only secure. It is easy to understand.
 
-That avoids one of the most common exchanges: fast send, reply from the doctor, second send to correct the file, more wasted time.
+The clinician should be able to tell, at a glance:
 
-### 3. Share only what is actually needed
+- whose report it is
+- what kind of exam it is
+- when it was performed
+- why it is being shared now
 
-If the doctor asks for one specific report, that may be enough. At most, add one or two documents that help explain the context.
+This is where structured document handling beats chat history. The file stops behaving like random media and starts behaving like part of a clinical record.
 
-Sending ten attachments at once does not always help.
+### 5. Keep a trace of the action
 
-A more useful share is often:
+The moment you share a report, that action becomes part of the care process.
 
-- the requested report
-- one related test if relevant
-- a short label or note that explains what the doctor is opening
+If it is tracked, the next step is simple:
 
-### 4. Keep track of what was shared
+- you know what was sent
+- you know to whom
+- you know when
+- you can reuse the same logic for the next specialist
 
-This is what makes future sharing easier.
+If it is not tracked, every new request feels like starting from zero.
 
-If you already know which documents were sent, to whom, and in what context, the next request becomes much lighter. You do not have to reconstruct the whole exchange again.
+## When you manage documents for a parent, child, or partner
 
-## If you manage records for a family member
+This is where weak workflows break fastest.
 
-This is where clarity matters even more.
-
-If you organise health documents for an older parent, a child, or a partner, you often sit between several people:
+If you are helping another family member, you are often coordinating between several people:
 
 - the GP
-- the specialist
+- one or more specialists
 - the clinic
 - the relative accompanying the visit
-- the caregiver
+- the caregiver handling logistics
 
-When reports move across different chats, it becomes much easier to lose the thread.
+In that setting, WhatsApp can still be useful for messages. But it becomes a poor substitute for a real document base.
 
-That is why it helps to keep a simple base:
+What you need instead is simple:
 
-- each person's documents clearly separated
-- the key reports easy to recover
-- sharing done in a more deliberate way
+- each person's records separated clearly
+- the important reports easy to retrieve
+- sharing that can be selective, not improvised
+- enough traceability to avoid asking the same question again and again
 
-The goal is not to build a complicated system.
+This is not about making care more technical. It is about reducing the invisible admin burden that families carry every week.
 
-It is to make the moment when someone says, "Can you send me that report?" feel lighter and more manageable.
+## What "better than WhatsApp" actually means
 
-## Speed and order can exist together
+People sometimes assume the only alternatives are:
 
-Many people use WhatsApp because they assume there are only two options:
+- keep doing everything in chat
+- adopt a complicated system that nobody will use
 
-- do everything quickly in chat
-- move into a complicated system
+That is a false choice.
 
-There is a third option.
+The useful middle ground is straightforward:
 
-You can still share quickly, but start from documents that are already organised and easier to control.
+- keep communication simple
+- keep documents organised
+- share from a controlled place
 
-That changes three things:
+That gives you the practical benefits that matter:
 
-- fewer mistakes
-- easier retrieval later
-- more confidence when sharing
+- less time spent searching
+- fewer duplicate sends
+- fewer wrong attachments
+- more confidence before appointments
 
-When health information is involved, that calm matters.
+In other words, speed and order can coexist.
 
-## The goal is not fewer tools. It is better document handling.
+## Where IppoLink fits
 
-WhatsApp is not the enemy.
+This is exactly the type of situation where [IppoLink]({% post_url en/2024-12-06-ippolink-launch %}){:target="_blank"} becomes useful.
 
-The real problem starts when it becomes the default archive for important health records.
+Instead of treating a chat thread as the archive, you prepare the right document first and then share it with more control. The doctor receives a clear access path to the material you chose to expose, while your archive stays organised for the next step.
 
-Chats are useful for coordination. Reports need a place where they remain findable, readable, and ready to share more deliberately.
+That distinction matters.
 
-If you often find yourself rushing to send a document to a doctor, the best next step is not sending faster.
+The goal is not to stop using WhatsApp for communication. The goal is to stop using it as the place where your family's health documentation becomes scattered, renamed, duplicated, and forgotten.
 
-It is preparing better.
+## A good health-sharing workflow should feel calmer, not heavier
 
-Because an important report should not disappear inside a conversation.
+When people talk about digital health tools, they often focus on features.
+
+The real test is simpler:
+
+When a doctor asks for a report, do you feel calm or do you feel rushed?
+
+If the answer is rushed, the problem is usually not the doctor. It is not even the phone. It is the lack of a reliable system behind the message.
+
+An important medical report should be:
+
+- easy to find
+- easy to verify
+- easy to share selectively
+- easy to recover later
+
+That is the standard families actually need.
+
+Because the safest way to send a report is not "faster chat."
+
+It is a better document workflow.
 
 <a href="https://app.ippocra.com/register?utm_source=blog&utm_medium=organic&utm_campaign=share-with-control" class="btn btn--primary btn--x-large">Start free with Ippocra<i class="fa-solid fa-arrow-right"></i></a>
 {: .text-center}
-
-### A practical note on IppoLink
-
-If you want a simpler way to share a document with more control, [IppoLink]({% post_url en/2024-12-06-ippolink-launch %}){:target="_blank"} is the most direct way to do it without turning a chat thread into your health archive.

--- a/_posts/en/2026-04-22-quando-un-medico-ti-chiede-un-referto-come-condividerlo-senza-usare-whatsapp.md
+++ b/_posts/en/2026-04-22-quando-un-medico-ti-chiede-un-referto-come-condividerlo-senza-usare-whatsapp.md
@@ -1,0 +1,239 @@
+---
+title: "When a Doctor Asks for a Report: How to Share It Without Using WhatsApp"
+categories: news
+permalink: /when-a-doctor-asks-for-a-report-how-to-share-it-without-using-whatsapp
+lang: en
+description: Learn how to share a health report with a doctor without relying on WhatsApp, with better control, clearer organisation, and less document confusion.
+keywords: share medical report without whatsapp, send health records to doctor, ippolink, share medical documents securely, organise family medical records, medical privacy.
+page_id: quando-un-medico-ti-chiede-un-referto-come-condividerlo-senza-usare-whatsapp
+header:
+    teaser: assets/images/ancona_view_belvedere_nord.webp
+classes: wide
+---
+
+![image-center](assets/images/ancona_view_belvedere_nord.webp){: .align-center}
+**When you need to send a medical report quickly, the job is not only sending it. It is finding it again, understanding it, and knowing who received it.**
+
+## WhatsApp feels fast. It does not always feel clear.
+
+When a doctor asks for a report, everything often happens quickly.
+
+A message arrives. A call comes in. Or an appointment ends with a simple request:
+
+> "Can you also send me the previous test results?"
+
+At that point, most people do the same thing. They open WhatsApp, look for the file, or a photo, or a screenshot, and send it.
+
+It feels like the fastest path. In the short term, it often is.
+
+The problem comes afterwards.
+
+Where did that report end up? Did you send the right file? Was it readable? Was it the latest version? Did you also send it to another doctor? If you need it again next month, will you be able to find it?
+
+The point is not that WhatsApp is "wrong". The point is that a chat thread was never designed to manage important health documents over time.
+
+When health information is involved, sharing should not only be fast. It should also be clear, organised, and under control.
+
+## Why chat feels convenient
+
+WhatsApp is already there.
+
+You use it every day. You already have the doctor's number, the family member's number, the caregiver's number, or the clinic contact. Taking a photo and sending it takes only a few seconds, so many families naturally use chat for reports, prescriptions, discharge letters, images, and treatment plans.
+
+The appeal is simple:
+
+- no new tool to learn
+- the file can be sent immediately
+- the doctor receives it in seconds
+
+If the need feels urgent, that can seem good enough.
+
+But health documents rarely matter only once. They often need to be found again, compared, resent, or shared more selectively later.
+
+That is where chat starts to show its limits.
+
+## The issue is not sending a file. It is managing what happens next.
+
+Once a report is shared in a chat, it quickly loses context.
+
+The same thread contains:
+
+- practical messages
+- voice notes
+- quick questions
+- other attachments
+- reminders
+- replies from different days or weeks
+
+After a short time, finding one important document becomes harder than expected.
+
+In many families, the same record is also sent multiple times:
+
+- to a GP
+- to a specialist
+- to a relative helping with care
+- to the person handling the booking
+
+The result is familiar: duplicate versions, low-quality photos, files spread across different chats, and no clear sense of what was shared with whom.
+
+The most common risk is not technical. It is practical.
+
+You lose time.
+
+You create confusion.
+
+And it happens exactly when clarity matters most.
+
+## What makes chat-based sharing fragile
+
+WhatsApp works well for quick coordination.
+
+A health report needs a little more structure.
+
+### 1. The document gets buried in the conversation
+
+An important file ends up mixed with dozens of unrelated messages. A few days later, recovering it depends on memory and patience.
+
+### 2. It is not always obvious which version you sent
+
+Did you send the PDF downloaded from the portal or a photo of the paper copy? Did you send the latest test or the one from last year? In chat, these mistakes are easier than they seem.
+
+### 3. There is no continuity
+
+Health documents rarely matter only once. They matter at the next visit, with the next specialist, during a follow-up, or when another family member needs context. If the file lives in a chat, each new share often starts from scratch.
+
+### 4. It is easier to overshare than to share well
+
+When you are rushed, it is tempting to send a whole stack of files "just in case". But the more you send without structure, the more noise you create for the person reading them.
+
+## In real life, privacy means control
+
+Health privacy is often discussed in abstract terms.
+
+For families, it usually comes down to something much more practical:
+
+knowing which documents you are sharing, with whom, and for what reason.
+
+This is not only about technical protection. It is about practical control.
+
+For example:
+
+- you may want to share one report without resending an entire medical history
+- you may want to send a document to a doctor without reviving old files inside a chat thread
+- you may need to keep one person's records separate from another family member's
+- you may want to quickly understand what has already been shared
+
+When sharing always happens through different chat threads, that control weakens.
+
+Not because people are careless, but because chat is not designed to be a clear, reliable home for shared health documents.
+
+## What to do instead when a doctor asks for a report
+
+The alternative is not to make life more complicated.
+
+The alternative is to make sharing simpler and clearer.
+
+A useful routine can look like this.
+
+### 1. Start from one archive
+
+The first benefit of keeping documents in one place is that you no longer need to remember whether the file was:
+
+- in chat
+- in email
+- in downloads
+- in your phone gallery
+- in an old paper folder you photographed months ago
+
+You search once. You find the right file. You start from there.
+
+### 2. Check that it is readable and current
+
+Before sharing, verify two simple things:
+
+- is this the correct document?
+- is it easy to read?
+
+That avoids one of the most common exchanges: fast send, reply from the doctor, second send to correct the file, more wasted time.
+
+### 3. Share only what is actually needed
+
+If the doctor asks for one specific report, that may be enough. At most, add one or two documents that help explain the context.
+
+Sending ten attachments at once does not always help.
+
+A more useful share is often:
+
+- the requested report
+- one related test if relevant
+- a short label or note that explains what the doctor is opening
+
+### 4. Keep track of what was shared
+
+This is what makes future sharing easier.
+
+If you already know which documents were sent, to whom, and in what context, the next request becomes much lighter. You do not have to reconstruct the whole exchange again.
+
+## If you manage records for a family member
+
+This is where clarity matters even more.
+
+If you organise health documents for an older parent, a child, or a partner, you often sit between several people:
+
+- the GP
+- the specialist
+- the clinic
+- the relative accompanying the visit
+- the caregiver
+
+When reports move across different chats, it becomes much easier to lose the thread.
+
+That is why it helps to keep a simple base:
+
+- each person's documents clearly separated
+- the key reports easy to recover
+- sharing done in a more deliberate way
+
+The goal is not to build a complicated system.
+
+It is to make the moment when someone says, "Can you send me that report?" feel lighter and more manageable.
+
+## Speed and order can exist together
+
+Many people use WhatsApp because they assume there are only two options:
+
+- do everything quickly in chat
+- move into a complicated system
+
+There is a third option.
+
+You can still share quickly, but start from documents that are already organised and easier to control.
+
+That changes three things:
+
+- fewer mistakes
+- easier retrieval later
+- more confidence when sharing
+
+When health information is involved, that calm matters.
+
+## The goal is not fewer tools. It is better document handling.
+
+WhatsApp is not the enemy.
+
+The real problem starts when it becomes the default archive for important health records.
+
+Chats are useful for coordination. Reports need a place where they remain findable, readable, and ready to share more deliberately.
+
+If you often find yourself rushing to send a document to a doctor, the best next step is not sending faster.
+
+It is preparing better.
+
+Because an important report should not disappear inside a conversation.
+
+<a href="https://app.ippocra.com/register?utm_source=blog&utm_medium=organic&utm_campaign=share-with-control" class="btn btn--primary btn--x-large">Start free with Ippocra<i class="fa-solid fa-arrow-right"></i></a>
+{: .text-center}
+
+### A practical note on IppoLink
+
+If you want a simpler way to share a document with more control, [IppoLink]({% post_url en/2024-12-06-ippolink-launch %}){:target="_blank"} is the most direct way to do it without turning a chat thread into your health archive.

--- a/_posts/it/2026-04-22-quando-un-medico-ti-chiede-un-referto-come-condividerlo-senza-usare-whatsapp.md
+++ b/_posts/it/2026-04-22-quando-un-medico-ti-chiede-un-referto-come-condividerlo-senza-usare-whatsapp.md
@@ -1,0 +1,239 @@
+---
+title: "Quando un medico ti chiede un referto: come condividerlo senza usare WhatsApp"
+categories: news
+permalink: /quando-un-medico-ti-chiede-un-referto-come-condividerlo-senza-usare-whatsapp
+lang: it
+description: Scopri come condividere un referto con un medico senza usare WhatsApp, con piu ordine, piu controllo e meno rischio di perdere file importanti.
+keywords: condividere referti senza whatsapp, inviare referti medici al medico, ippolink, condividere documenti sanitari, privacy documenti sanitari, organizzare referti medici.
+page_id: quando-un-medico-ti-chiede-un-referto-come-condividerlo-senza-usare-whatsapp
+header:
+    teaser: assets/images/ancona_view_belvedere_nord.webp
+classes: wide
+---
+
+![image-center](assets/images/ancona_view_belvedere_nord.webp){: .align-center}
+**Quando serve inviare un referto in fretta, il punto non e solo mandarlo. E ritrovarlo, capirlo, e sapere con chi lo hai condiviso.**
+
+## WhatsApp sembra la strada piu veloce. Ma non sempre e la piu chiara.
+
+Quando un medico ti chiede un referto, spesso succede tutto molto in fretta.
+
+Arriva un messaggio. Oppure una chiamata. O magari una visita si chiude con una richiesta semplice:
+
+> "Mi mandi anche gli esami precedenti?"
+
+In quel momento quasi tutti fanno la stessa cosa. Aprono WhatsApp. Cercano il file. O una foto. O uno screenshot. E inviano.
+
+Sembra la strada piu rapida. Nel brevissimo momento, spesso lo e.
+
+Il problema arriva dopo.
+
+Dove e finito quel referto? Hai mandato il file giusto? Era leggibile? Era l'ultima versione? Lo hai rimandato anche a un altro medico? Se tra un mese ti serve di nuovo, lo ritrovi?
+
+Il punto non e dire che WhatsApp sia "sbagliato". Il punto e che una chat non nasce per gestire documenti sanitari importanti nel tempo.
+
+Quando si parla di salute, la condivisione non dovrebbe essere solo veloce. Dovrebbe essere anche chiara, ordinata e sotto controllo.
+
+## Perche la chat sembra comoda
+
+WhatsApp e gia li.
+
+Lo usi ogni giorno. Hai il numero del medico, del familiare, del caregiver, dello studio. Fare una foto e inviarla richiede pochi secondi. Per questo tante famiglie si appoggiano alle chat anche per referti, prescrizioni, lettere di dimissione, immagini e piani terapeutici.
+
+Il vantaggio percepito e semplice:
+
+- non devi imparare un nuovo strumento
+- puoi inviare subito
+- il medico riceve il file in pochi istanti
+
+Se il bisogno e urgente, e facile pensare che basti questo.
+
+Ma i documenti sanitari non vivono in un singolo momento. Spesso devono essere ritrovati, confrontati, reinviati o condivisi solo con alcune persone e non con altre.
+
+Ed e qui che la chat inizia a mostrare i suoi limiti.
+
+## Il problema non e inviare. E gestire quello che succede dopo.
+
+Quando un referto viene condiviso in chat, spesso perde subito contesto.
+
+Nel thread si mescolano:
+
+- messaggi pratici
+- audio
+- domande veloci
+- altri allegati
+- promemoria
+- risposte di giorni o settimane diverse
+
+Dopo poco tempo, ritrovare un documento diventa piu difficile del previsto.
+
+In molte famiglie la stessa informazione viene inviata piu volte:
+
+- al medico di base
+- a uno specialista
+- a un familiare che accompagna alla visita
+- a chi si occupa delle prenotazioni
+
+Risultato: versioni duplicate, foto poco leggibili, file sparsi in piu chat, e la sensazione di non sapere piu esattamente cosa e stato condiviso e con chi.
+
+Il rischio piu comune non e tecnico. E pratico.
+
+Si perde tempo.
+
+Si genera confusione.
+
+E proprio nel momento in cui servirebbe piu chiarezza.
+
+## Cosa rende fragile la condivisione in chat
+
+WhatsApp puo andare bene per dirsi "arrivo tra dieci minuti" o "ci sentiamo dopo".
+
+Un referto, invece, ha bisogno di qualche attenzione in piu.
+
+### 1. Il documento si confonde con la conversazione
+
+Un file importante finisce in mezzo a decine di messaggi. Dopo qualche giorno, recuperarlo richiede memoria e pazienza.
+
+### 2. Non sempre e chiaro quale versione hai inviato
+
+Hai mandato il PDF scaricato dal portale o la foto fatta al foglio? Hai inviato l'ultimo esame o quello dell'anno scorso? Nelle chat questi errori sono piu facili di quanto sembri.
+
+### 3. Manca continuita
+
+Un documento sanitario spesso non serve una volta sola. Serve alla visita successiva, a un nuovo specialista, a un controllo, o a un familiare che deve capire il contesto. Se resta legato a una chat, ogni nuova condivisione riparte quasi da zero.
+
+### 4. Condividere tutto e piu facile che condividere bene
+
+Quando sei di fretta, la tentazione e inviare intere sequenze di file "per sicurezza". Ma piu documenti mandi senza criterio, piu aumenti il rumore per chi li deve leggere.
+
+## La privacy, nella vita reale, e una questione di controllo
+
+Quando si parla di privacy sanitaria, spesso il discorso resta astratto.
+
+In realta, per una famiglia, privacy significa una cosa molto concreta:
+
+sapere quali documenti stai condividendo, con chi, e per quale motivo.
+
+Non e solo una questione di protezione tecnica. E una questione di controllo pratico.
+
+Per esempio:
+
+- puoi voler condividere solo un referto e non tutta la storia clinica
+- puoi aver bisogno di inviare un documento a un medico senza rimettere in circolo vecchi allegati in chat
+- puoi voler distinguere i file di un genitore da quelli di un figlio o del partner
+- puoi aver bisogno di ritrovare rapidamente cosa hai gia inviato
+
+Quando la condivisione passa sempre da chat diverse, questo controllo si indebolisce.
+
+Non perche chi usa la chat sbaglia. Ma perche la chat non e pensata per essere un archivio chiaro e affidabile dei documenti sanitari condivisi.
+
+## Cosa fare invece quando un medico chiede un referto
+
+L'alternativa non e complicarsi la vita.
+
+L'alternativa e preparare una condivisione piu semplice e piu leggibile.
+
+Una buona routine puo essere questa.
+
+### 1. Recupera il documento giusto da un archivio unico
+
+Il primo vantaggio di avere i documenti in un solo posto e che non devi ricordarti se il file era:
+
+- in chat
+- in email
+- tra i download
+- nella galleria del telefono
+- in una cartellina cartacea fotografata mesi fa
+
+Cerchi una volta. Trovi il file giusto. Parti da li.
+
+### 2. Verifica che sia leggibile e aggiornato
+
+Prima di condividere, controlla due cose molto semplici:
+
+- e il documento corretto?
+- si legge bene?
+
+Questo evita uno degli scambi piu comuni: invio veloce, risposta del medico, secondo invio per correggere il file, nuova perdita di tempo.
+
+### 3. Condividi solo quello che serve davvero
+
+Se il medico chiede un referto specifico, spesso basta quello. Al massimo, uno o due documenti che aiutano a capire il contesto.
+
+Mandare dieci allegati in una volta non aiuta sempre.
+
+Spesso aiuta di piu una selezione chiara:
+
+- il referto richiesto
+- l'eventuale esame collegato
+- una nota o un titolo che faccia capire cosa si sta guardando
+
+### 4. Mantieni traccia di cosa hai condiviso
+
+Questo e il punto che fa la differenza nel tempo.
+
+Se sai gia quali documenti hai inviato, a chi, e in quale occasione, la condivisione successiva diventa piu semplice. Non devi ricostruire tutto da capo.
+
+## Se gestisci i documenti per un familiare
+
+Qui l'ordine diventa ancora piu importante.
+
+Chi segue i documenti di un genitore, di un figlio, o di un partner spesso deve fare da ponte tra piu persone:
+
+- medico curante
+- specialista
+- struttura
+- familiare che accompagna
+- caregiver
+
+Quando i referti viaggiano in chat diverse, il rischio di perdere il filo cresce subito.
+
+Per questo conviene avere una base chiara:
+
+- i documenti di ogni persona separati e riconoscibili
+- i referti piu importanti facili da recuperare
+- le condivisioni fatte in modo piu mirato
+
+L'obiettivo non e costruire un sistema complesso.
+
+E togliere peso al momento in cui qualcuno dice: "Mi mandi quel referto?"
+
+## Velocita e ordine possono stare insieme
+
+Molte persone usano WhatsApp perche pensano di dover scegliere tra due estremi:
+
+- o fai tutto al volo
+- o devi entrare in un sistema complicato
+
+In realta c'e una terza strada.
+
+Puoi condividere rapidamente, ma partendo da documenti gia ordinati e da una logica piu chiara.
+
+Questo cambia tre cose:
+
+- riduci gli errori
+- ritrovi piu facilmente quello che hai gia inviato
+- condividi con piu tranquillita
+
+Quando si parla di salute, questa calma conta molto.
+
+## Il punto non e usare meno strumenti. E usare meglio i documenti.
+
+WhatsApp non e il problema in se.
+
+Il problema nasce quando diventa l'archivio di fatto dei tuoi documenti sanitari.
+
+Le chat sono utili per coordinarsi. I referti hanno bisogno di un posto dove restare trovabili, leggibili e pronti da condividere con piu criterio.
+
+Se oggi ti capita spesso di cercare all'ultimo un documento da mandare a un medico, il miglior passo non e inviare piu in fretta.
+
+E preparare meglio quello che vuoi condividere.
+
+Perche un referto importante non dovrebbe perdersi in mezzo a una conversazione.
+
+<a href="https://app.ippocra.com/register?utm_source=blog&utm_medium=organic&utm_campaign=share-with-control" class="btn btn--primary btn--x-large">Inizia gratis con Ippocra<i class="fa-solid fa-arrow-right"></i></a>
+{: .text-center}
+
+### Una nota pratica su IppoLink
+
+Se vuoi condividere un documento con piu controllo, [IppoLink]({% post_url it/2024-12-06-ippolink-launch %}){:target="_blank"} e il modo piu semplice per farlo senza trasformare una chat nel tuo archivio sanitario.

--- a/_posts/it/2026-04-22-quando-un-medico-ti-chiede-un-referto-come-condividerlo-senza-usare-whatsapp.md
+++ b/_posts/it/2026-04-22-quando-un-medico-ti-chiede-un-referto-come-condividerlo-senza-usare-whatsapp.md
@@ -64,7 +64,7 @@ Questo significa che la qualita della condivisione conta quasi quanto la velocit
 
 ## Cosa si rompe davvero quando usi la chat per i referti
 
-Quasi mai succede un disastro evidente. Più spesso succedono piccoli problemi ripetuti, e sono proprio quelli a consumare tempo e fiducia.
+Quasi mai succede un disastro evidente. Piu spesso succedono piccoli problemi ripetuti, e sono proprio quelli a consumare tempo e fiducia.
 
 ### 1. Il file perde subito contesto
 

--- a/_posts/it/2026-04-22-quando-un-medico-ti-chiede-un-referto-come-condividerlo-senza-usare-whatsapp.md
+++ b/_posts/it/2026-04-22-quando-un-medico-ti-chiede-un-referto-come-condividerlo-senza-usare-whatsapp.md
@@ -12,228 +12,261 @@ classes: wide
 ---
 
 ![image-center](assets/images/ancona_view_belvedere_nord.webp){: .align-center}
-**Quando serve inviare un referto in fretta, il punto non e solo mandarlo. E ritrovarlo, capirlo, e sapere con chi lo hai condiviso.**
+**Quando un medico ti chiede un referto, la parte difficile non e premere "invio". La parte difficile e mandare il file giusto, con il contesto giusto, senza creare nuova confusione alla visita successiva.**
 
-## WhatsApp sembra la strada piu veloce. Ma non sempre e la piu chiara.
+## Il problema vero inizia dopo il messaggio
 
-Quando un medico ti chiede un referto, spesso succede tutto molto in fretta.
+Di solito succede tutto in fretta.
 
-Arriva un messaggio. Oppure una chiamata. O magari una visita si chiude con una richiesta semplice:
+Stai uscendo da una visita. Il medico dice: "Mi mandi anche gli esami del sangue?" Oppure ti chiama il centro e chiede l'ultima ecografia prima di confermare l'appuntamento.
 
-> "Mi mandi anche gli esami precedenti?"
+Quasi tutti reagiscono allo stesso modo:
 
-In quel momento quasi tutti fanno la stessa cosa. Aprono WhatsApp. Cercano il file. O una foto. O uno screenshot. E inviano.
+- aprono WhatsApp
+- scorrono vecchie chat
+- cercano un PDF, una foto o uno screenshot
+- inviano quello che sembra il file giusto
 
-Sembra la strada piu rapida. Nel brevissimo momento, spesso lo e.
+In quel momento la chat sembra efficiente. Il contatto c'e gia. Il medico la usa gia. Bastano pochi secondi.
 
-Il problema arriva dopo.
+Pero il lavoro sanitario non finisce quando il file parte dal telefono.
 
-Dove e finito quel referto? Hai mandato il file giusto? Era leggibile? Era l'ultima versione? Lo hai rimandato anche a un altro medico? Se tra un mese ti serve di nuovo, lo ritrovi?
+Subito dopo arrivano le domande vere:
 
-Il punto non e dire che WhatsApp sia "sbagliato". Il punto e che una chat non nasce per gestire documenti sanitari importanti nel tempo.
+- ho mandato il referto piu aggiornato?
+- era il PDF corretto o una foto poco leggibile?
+- l'ho gia mandato a un altro specialista?
+- tra un mese sapro ritrovarlo?
+- se un familiare deve aiutarmi, capira subito cosa e stato condiviso?
 
-Quando si parla di salute, la condivisione non dovrebbe essere solo veloce. Dovrebbe essere anche chiara, ordinata e sotto controllo.
+Per questo WhatsApp non e "il nemico". Il punto e un altro: una conversazione non e un workflow documentale.
 
-## Perche la chat sembra comoda
+## Perche WhatsApp sembra sufficiente finche non smette di esserlo
 
-WhatsApp e gia li.
+WhatsApp risolve molto bene un problema preciso: il coordinamento rapido.
 
-Lo usi ogni giorno. Hai il numero del medico, del familiare, del caregiver, dello studio. Fare una foto e inviarla richiede pochi secondi. Per questo tante famiglie si appoggiano alle chat anche per referti, prescrizioni, lettere di dimissione, immagini e piani terapeutici.
+Va benissimo per messaggi come:
 
-Il vantaggio percepito e semplice:
+- "Arrivo tra dieci minuti"
+- "La visita e stata spostata"
+- "Richiamami quando puoi"
 
-- non devi imparare un nuovo strumento
-- puoi inviare subito
-- il medico riceve il file in pochi istanti
+Diventa molto piu debole quando il compito e:
 
-Se il bisogno e urgente, e facile pensare che basti questo.
+- recuperare il documento clinico corretto
+- condividere solo quello che serve
+- tenere traccia di cio che e stato inviato
+- ripetere la stessa operazione con calma in futuro
 
-Ma i documenti sanitari non vivono in un singolo momento. Spesso devono essere ritrovati, confrontati, reinviati o condivisi solo con alcune persone e non con altre.
+I documenti sanitari non sono allegati qualsiasi. Spesso devono essere ritrovati, confrontati, reinviati a un altro medico, o tenuti pronti per un familiare che sta seguendo la situazione.
 
-Ed e qui che la chat inizia a mostrare i suoi limiti.
+Questo significa che la qualita della condivisione conta quasi quanto la velocita.
 
-## Il problema non e inviare. E gestire quello che succede dopo.
+## Cosa si rompe davvero quando usi la chat per i referti
 
-Quando un referto viene condiviso in chat, spesso perde subito contesto.
+Quasi mai succede un disastro evidente. Più spesso succedono piccoli problemi ripetuti, e sono proprio quelli a consumare tempo e fiducia.
 
-Nel thread si mescolano:
+### 1. Il file perde subito contesto
+
+Il referto finisce in mezzo a:
 
 - messaggi pratici
 - audio
+- promemoria
 - domande veloci
 - altri allegati
-- promemoria
-- risposte di giorni o settimane diverse
 
-Dopo poco tempo, ritrovare un documento diventa piu difficile del previsto.
+Dopo due settimane nessuno ricorda piu se quel PDF era l'esame del sangue, la lettera di dimissione o il referto radiologico.
 
-In molte famiglie la stessa informazione viene inviata piu volte:
+### 2. Iniziano a circolare versioni diverse
 
-- al medico di base
-- a uno specialista
-- a un familiare che accompagna alla visita
-- a chi si occupa delle prenotazioni
+Una persona manda il PDF scaricato dal portale. Un'altra inoltra la foto del foglio. Un familiare rimanda lo stesso esame con un nome file diverso. A quel punto non state piu gestendo un documento: state cercando di capire quale documento sia quello giusto.
 
-Risultato: versioni duplicate, foto poco leggibili, file sparsi in piu chat, e la sensazione di non sapere piu esattamente cosa e stato condiviso e con chi.
+### 3. La fretta porta a condividere troppo
 
-Il rischio piu comune non e tecnico. E pratico.
+Quando il medico chiede un referto, molte famiglie ne mandano cinque "per sicurezza". Sul momento sembra prudenza. In pratica aggiunge rumore per chi legge e incertezza per chi invia.
 
-Si perde tempo.
+Condividere bene non vuol dire mandare tutto. Vuol dire mandare il minimo indispensabile per far avanzare la conversazione clinica.
 
-Si genera confusione.
+### 4. Nessuno riesce a ricostruire cosa e successo
 
-E proprio nel momento in cui servirebbe piu chiarezza.
+Questo e il problema piu sottovalutato.
 
-## Cosa rende fragile la condivisione in chat
+Alla visita dopo qualcuno chiede:
 
-WhatsApp puo andare bene per dirsi "arrivo tra dieci minuti" o "ci sentiamo dopo".
+> "Il referto di cardiologia lo avevamo gia mandato?"
 
-Un referto, invece, ha bisogno di qualche attenzione in piu.
+Se la risposta vive in tre chat diverse e nella memoria di un familiare, il sistema e gia fragile.
 
-### 1. Il documento si confonde con la conversazione
+## La privacy, nella pratica, significa controllo
 
-Un file importante finisce in mezzo a decine di messaggi. Dopo qualche giorno, recuperarlo richiede memoria e pazienza.
+Quando si sente la parola "privacy", spesso si pensa a regolamenti, impostazioni o linguaggio tecnico.
 
-### 2. Non sempre e chiaro quale versione hai inviato
+Nella vita reale di chi gestisce la salute, privacy significa qualcosa di molto piu concreto:
 
-Hai mandato il PDF scaricato dal portale o la foto fatta al foglio? Hai inviato l'ultimo esame o quello dell'anno scorso? Nelle chat questi errori sono piu facili di quanto sembri.
+- condividere un solo referto senza esporre tutta la storia clinica
+- tenere distinti i documenti di persone diverse
+- sapere chi ha ricevuto cosa
+- evitare l'abitudine di mandare tutto a tutti
 
-### 3. Manca continuita
+Ecco perche la chat lascia spesso una sensazione di scomodita, anche quando ci si fida del medico o della struttura. Il problema non e solo la riservatezza. Il problema e il controllo.
 
-Un documento sanitario spesso non serve una volta sola. Serve alla visita successiva, a un nuovo specialista, a un controllo, o a un familiare che deve capire il contesto. Se resta legato a una chat, ogni nuova condivisione riparte quasi da zero.
+Un documento clinico dovrebbe essere facile da condividere con intenzione, non facile da spargere per abitudine.
 
-### 4. Condividere tutto e piu facile che condividere bene
+## Cosa fare, invece, quando un medico ti chiede un referto
 
-Quando sei di fretta, la tentazione e inviare intere sequenze di file "per sicurezza". Ma piu documenti mandi senza criterio, piu aumenti il rumore per chi li deve leggere.
+L'alternativa non e aggiungere burocrazia. L'alternativa e avere una routine piu pulita.
 
-## La privacy, nella vita reale, e una questione di controllo
+Una buona condivisione, nella pratica, funziona cosi.
 
-Quando si parla di privacy sanitaria, spesso il discorso resta astratto.
+### 1. Parti da un archivio unico, non dalla memoria
 
-In realta, per una famiglia, privacy significa una cosa molto concreta:
+Il primo passo non dovrebbe essere: "Dove l'avevo messo?"
 
-sapere quali documenti stai condividendo, con chi, e per quale motivo.
+Dovrebbe essere: "Apro l'archivio, cerco il referto, controllo la data."
 
-Non e solo una questione di protezione tecnica. E una questione di controllo pratico.
+Questo cambio sembra piccolo, ma elimina la parte piu stressante. Non stai piu cercando tra:
 
-Per esempio:
+- chat
+- email
+- download
+- galleria del telefono
+- documenti cartacei fotografati mesi fa
 
-- puoi voler condividere solo un referto e non tutta la storia clinica
-- puoi aver bisogno di inviare un documento a un medico senza rimettere in circolo vecchi allegati in chat
-- puoi voler distinguere i file di un genitore da quelli di un figlio o del partner
-- puoi aver bisogno di ritrovare rapidamente cosa hai gia inviato
+Parti da un posto noto. E gia questo abbassa il caos.
 
-Quando la condivisione passa sempre da chat diverse, questo controllo si indebolisce.
+### 2. Verifica il documento prima di inviarlo
 
-Non perche chi usa la chat sbaglia. Ma perche la chat non e pensata per essere un archivio chiaro e affidabile dei documenti sanitari condivisi.
+Prima di condividere, controlla tre cose:
 
-## Cosa fare invece quando un medico chiede un referto
+- e la persona giusta?
+- e la versione giusta?
+- si legge senza spiegazioni?
 
-L'alternativa non e complicarsi la vita.
+Ci vuole meno di un minuto e ti evita il loop piu comune nella messaggistica sanitaria:
 
-L'alternativa e preparare una condivisione piu semplice e piu leggibile.
+1. invio veloce
+2. risposta "non si legge" oppure "intendevo quello precedente"
+3. nuovo invio
+4. sensazione di avere perso il controllo
 
-Una buona routine puo essere questa.
+### 3. Invia il set minimo utile
 
-### 1. Recupera il documento giusto da un archivio unico
+Se il medico chiede un referto, parti da quel referto.
 
-Il primo vantaggio di avere i documenti in un solo posto e che non devi ricordarti se il file era:
-
-- in chat
-- in email
-- tra i download
-- nella galleria del telefono
-- in una cartellina cartacea fotografata mesi fa
-
-Cerchi una volta. Trovi il file giusto. Parti da li.
-
-### 2. Verifica che sia leggibile e aggiornato
-
-Prima di condividere, controlla due cose molto semplici:
-
-- e il documento corretto?
-- si legge bene?
-
-Questo evita uno degli scambi piu comuni: invio veloce, risposta del medico, secondo invio per correggere il file, nuova perdita di tempo.
-
-### 3. Condividi solo quello che serve davvero
-
-Se il medico chiede un referto specifico, spesso basta quello. Al massimo, uno o due documenti che aiutano a capire il contesto.
-
-Mandare dieci allegati in una volta non aiuta sempre.
-
-Spesso aiuta di piu una selezione chiara:
+Se serve contesto, aggiungi un secondo documento con criterio. Per esempio:
 
 - il referto richiesto
-- l'eventuale esame collegato
-- una nota o un titolo che faccia capire cosa si sta guardando
+- l'esame precedente per confronto
+- una nota breve che spiega perche lo stai condividendo
 
-### 4. Mantieni traccia di cosa hai condiviso
+Questo e molto diverso dal lanciare dieci allegati in chat sperando che il file giusto si faccia notare da solo.
 
-Questo e il punto che fa la differenza nel tempo.
+### 4. Rendi chiara la condivisione a chi riceve
 
-Se sai gia quali documenti hai inviato, a chi, e in quale occasione, la condivisione successiva diventa piu semplice. Non devi ricostruire tutto da capo.
+Una buona condivisione non e solo sicura. E leggibile.
 
-## Se gestisci i documenti per un familiare
+Chi riceve dovrebbe capire subito:
 
-Qui l'ordine diventa ancora piu importante.
+- di chi e il referto
+- che tipo di esame sta aprendo
+- quando e stato fatto
+- perche lo sta ricevendo proprio adesso
 
-Chi segue i documenti di un genitore, di un figlio, o di un partner spesso deve fare da ponte tra piu persone:
+Qui si vede la differenza tra una gestione documentale vera e una semplice cronologia di messaggi. Il file smette di comportarsi come un allegato qualsiasi e torna a comportarsi come parte di una storia clinica.
 
-- medico curante
-- specialista
-- struttura
+### 5. Tieni traccia dell'azione
+
+Quando condividi un referto, quella condivisione diventa parte del percorso di cura.
+
+Se resta tracciata, la volta dopo tutto e piu semplice:
+
+- sai cosa hai inviato
+- sai a chi
+- sai quando
+- puoi riutilizzare la stessa logica con un altro specialista
+
+Se non resta tracciata, ogni nuova richiesta ti costringe a ripartire da zero.
+
+## Se gestisci i documenti di un genitore, di un figlio o del partner
+
+E qui che i workflow deboli si rompono piu in fretta.
+
+Chi segue un familiare si trova spesso a coordinare:
+
+- medico di base
+- specialisti
+- struttura sanitaria
 - familiare che accompagna
-- caregiver
+- caregiver che gestisce la logistica
 
-Quando i referti viaggiano in chat diverse, il rischio di perdere il filo cresce subito.
+In questo contesto WhatsApp puo restare utile per i messaggi. Ma e un sostituto debole per una base documentale vera.
 
-Per questo conviene avere una base chiara:
+Quello che serve, invece, e semplice:
 
-- i documenti di ogni persona separati e riconoscibili
-- i referti piu importanti facili da recuperare
-- le condivisioni fatte in modo piu mirato
+- documenti separati chiaramente per ogni persona
+- referti importanti facili da recuperare
+- condivisioni selettive, non improvvisate
+- abbastanza tracciabilita da non dover rifare sempre le stesse domande
 
-L'obiettivo non e costruire un sistema complesso.
+Non si tratta di rendere la cura piu tecnica. Si tratta di ridurre quel lavoro invisibile di amministrazione sanitaria che le famiglie si portano addosso ogni settimana.
 
-E togliere peso al momento in cui qualcuno dice: "Mi mandi quel referto?"
+## Cosa significa davvero "meglio di WhatsApp"
 
-## Velocita e ordine possono stare insieme
+Molte persone pensano che le opzioni siano solo due:
 
-Molte persone usano WhatsApp perche pensano di dover scegliere tra due estremi:
+- continuare a fare tutto in chat
+- entrare in un sistema complicato che nessuno usera
 
-- o fai tutto al volo
-- o devi entrare in un sistema complicato
+E una falsa scelta.
 
-In realta c'e una terza strada.
+La via utile in mezzo e piu concreta:
 
-Puoi condividere rapidamente, ma partendo da documenti gia ordinati e da una logica piu chiara.
+- comunicazione semplice
+- documenti ordinati
+- condivisione da un posto controllato
 
-Questo cambia tre cose:
+Questo ti da i vantaggi che contano davvero:
 
-- riduci gli errori
-- ritrovi piu facilmente quello che hai gia inviato
-- condividi con piu tranquillita
+- meno tempo perso a cercare
+- meno invii duplicati
+- meno allegati sbagliati
+- piu tranquillita prima delle visite
 
-Quando si parla di salute, questa calma conta molto.
+In altre parole, velocita e ordine possono stare insieme.
 
-## Il punto non e usare meno strumenti. E usare meglio i documenti.
+## Dove entra in gioco IppoLink
 
-WhatsApp non e il problema in se.
+E proprio in situazioni come questa che [IppoLink]({% post_url it/2024-12-06-ippolink-launch %}){:target="_blank"} diventa utile.
 
-Il problema nasce quando diventa l'archivio di fatto dei tuoi documenti sanitari.
+Invece di trasformare la chat nell'archivio, prepari prima il documento giusto e poi lo condividi con piu controllo. Il medico riceve un accesso chiaro al materiale che hai deciso di esporre, mentre il tuo archivio resta ordinato per il passaggio successivo.
 
-Le chat sono utili per coordinarsi. I referti hanno bisogno di un posto dove restare trovabili, leggibili e pronti da condividere con piu criterio.
+Questa differenza conta.
 
-Se oggi ti capita spesso di cercare all'ultimo un documento da mandare a un medico, il miglior passo non e inviare piu in fretta.
+L'obiettivo non e smettere di usare WhatsApp per comunicare. L'obiettivo e smettere di usarlo come luogo in cui i documenti sanitari si spargono, si duplicano, cambiano nome e poi spariscono.
 
-E preparare meglio quello che vuoi condividere.
+## Un buon workflow sanitario dovrebbe dare calma, non peso
 
-Perche un referto importante non dovrebbe perdersi in mezzo a una conversazione.
+Quando si parla di strumenti digitali per la salute, spesso si ragiona in termini di funzionalita.
+
+La prova vera e piu semplice:
+
+Quando un medico ti chiede un referto, ti senti tranquillo o ti senti in affanno?
+
+Se la risposta e "in affanno", di solito il problema non e il medico. Non e nemmeno il telefono. E il fatto che dietro al messaggio non c'e un sistema affidabile.
+
+Un referto importante dovrebbe essere:
+
+- facile da trovare
+- facile da verificare
+- facile da condividere in modo selettivo
+- facile da recuperare dopo
+
+Questo e lo standard di cui le famiglie hanno davvero bisogno.
+
+Perche il modo piu sicuro di inviare un referto non e "piu chat".
+
+E un workflow documentale migliore.
 
 <a href="https://app.ippocra.com/register?utm_source=blog&utm_medium=organic&utm_campaign=share-with-control" class="btn btn--primary btn--x-large">Inizia gratis con Ippocra<i class="fa-solid fa-arrow-right"></i></a>
 {: .text-center}
-
-### Una nota pratica su IppoLink
-
-Se vuoi condividere un documento con piu controllo, [IppoLink]({% post_url it/2024-12-06-ippolink-launch %}){:target="_blank"} e il modo piu semplice per farlo senza trasformare una chat nel tuo archivio sanitario.


### PR DESCRIPTION
## Summary
- add the Italian and English April 22 article pair for the week-of-April-20 "Secure sharing instead of WhatsApp" theme
- keep the copy aligned with the current Ippocra voice: calm, practical, and privacy-aware
- keep the posts scheduled for 2026-04-22 so they are ready for board review before publication

## Validation
- parsed both post frontmatters successfully
- ran `bundle exec jekyll build` with a repo-local Bundler path
- expected warning: the two new posts are future-dated on 2026-04-03, so Jekyll skips them in the build by default until 2026-04-22

## Source
- board review lane: [IPP-40](https://paperclip.local/IPP/issues/IPP-40)