### PR TITLE
it/about: rewrite hero and bios to lead with Ippo+Ideallab dual identity

### DIFF
--- a/_pages/it/_inner_about.html
+++ b/_pages/it/_inner_about.html
@@ -13,11 +13,13 @@
                     <p class="mt-4 paragraph-lg" style="color:#3b9ba8;">
                         Un team con un obiettivo semplice: rendere la salute più gestibile per le persone.
                     </p>
-                    <div class="mt-6 max-w-2xl mx-auto leading-relaxed">
+                    <div class="mt-6 max-w-3xl mx-auto leading-relaxed">
                         <p class="paragraph-md">
-                            Ippocra nasce da un problema personale: documenti sanitari sparsi, difficili da trovare
-                            e impossibili da condividere quando serve davvero.
-                            Il nostro lavoro è trasformare questa complessità in qualcosa di chiaro, sicuro e umano.
+                            Ippocra è la fusione di due visioni:
+                            <strong>Ippo</strong>, la piattaforma sanitaria per le famiglie,
+                            e <strong>Ideallab</strong>, la consulenza software e AI per le imprese.
+                            Siamo nati da un problema personale — documenti sparsi e difficili da condividere —
+                            e abbiamo costruito due attività complementari per risolverlo.
                         </p>
                     </div>
                     <p class="mt-8 paragraph-lg paragraph-bold" style="color:#3b9ba8;">
@@ -78,12 +80,10 @@
                         <h3 class="text-xl font-bold text-gray-900 mb-1">Michele Mattioni</h3>
                         <p class="text-sm font-semibold mb-4" style="color:#3b9ba8;">Founder</p>
                         <p class="paragraph-md text-gray-700">
-                            Fondatore di Ippocra, che opera su due fronti complementari:
-                            la piattaforma Ippo per la salute digitale delle famiglie e Ideallab,
-                            la consulenza software e AI per le imprese.
-                            Guida il prodotto Ippo partendo da casi d'uso reali,
-                            con un focus su chiarezza, privacy e utilità,
-                            mentre la visione tecnica viene alimentata anche dal mondo Ideallab.
+                            Fondatore di Ippocra. Guida lo sviluppo di Ippo, la piattaforma per la salute digitale delle famiglie,
+                            e al tempo stesso alimenta la visione tecnica di Ideallab, la consulenza software e AI.
+                            Il suo approccio parte sempre dai casi d'uso reali,
+                            con un focus su chiarezza, privacy e utilità.
                         </p>
                     </div>
 
@@ -95,9 +95,8 @@
                         <h3 class="text-xl font-bold text-gray-900 mb-1">Myrto Kostadima</h3>
                         <p class="text-sm font-semibold mb-4" style="color:#3b9ba8;">Co-founder</p>
                         <p class="paragraph-md text-gray-700">
-                            Co-fondatrice: tiene uniti i due volti di Ippocra, Ippo e Ideallab.
-                            Coordina le operazioni e i processi aziendali attraverso entrambe le attività,
-                            garantendo che crescano in modo strutturato,
+                            Co-fondatrice di Ippocra: coordina Ippo e Ideallab come un unico ecosistema.
+                            Trasforma due attività apparentemente distinte in processi fluidi e strutturati,
                             permettendo al team di concentrarsi su prodotto e innovazione.
                         </p>
                     </div>


### PR DESCRIPTION
## Changes

Italian 'Chi Siamo' page — three sections rewritten to properly reflect Ippocra as **Ippo + Ideallab** (not Ippo-first with Ideallab as an afterthought):

### Hero
**Before:** Started with the personal problem origin story.
**After:** Leads with the dual-pillar identity — Ippo (health platform) + Ideallab (AI consultancy) — and frames the personal problem as the origin, not the main message.

### Michele Mattioni
**Before:** Framed as "product guy for Ippo" with Ideallab as an afterthought.
**After:** "Fondatore di Ippocra" — equal weight to both sides, positions him as building both Ippo and feeding Ideallab's technical vision.

### Myrto Kostadima
**Before:** "tiene uniti i due volti" — frames them as separate faces.
**After:** "coordina Ippo e Ideallab come un unico ecosistema" — integrated framing, two activities made into one.

### File changed
- `_pages/it/_inner_about.html` — 3 sections updated
