### PR TITLE
feat: add ideallab analytics and session recorder

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,6 +24,10 @@
 <link rel="preload" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@latest/css/all.min.css&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
 <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@latest/css/all.min.css"></noscript>
 
+<!-- ideallab analytics -->
+<script defer src="https://analytics.ideallab.org/script.js" data-website-id="07e6f4cb-81cb-43e0-b51c-0922e45f02f7"></script>
+<script defer src="https://analytics.ideallab.org/recorder.js" data-website-id="07e6f4cb-81cb-43e0-b51c-0922e45f02f7" data-sample-rate="0.15" data-mask-level="moderate" data-max-duration="300000"></script>
+
 {% if site.head_scripts %}
   {% for script in site.head_scripts %}
     <script src="{{ script | relative_url }}"></script>


### PR DESCRIPTION
## Summary

- Add ideallab analytics script (`script.js`) for site tracking
- Add ideallab session recorder (`recorder.js`) with:
  - 15% sample rate
  - Moderate masking
  - 5-minute max session duration

Both scripts load deferred in `<head>` via `_includes/head.html` and will apply to all three language versions (`/it/`, `/en/`, `/el/`).

## Test Plan

- [ ] CI passes (GitHub Pages build)
- [ ] Verify scripts load on `https://ippocra.github.io`