### PR TITLE
fix(en): fix English post routing and content

### DIFF
--- a/_posts/en/2026-05-25-from-ippo-to-ideallab.md
+++ b/_posts/en/2026-05-25-from-ippo-to-ideallab.md
@@ -1,7 +1,6 @@
 ---
 title: "From Ippo to Ideallab: How We Found Our Direction"
 categories: news
-permalink: /da-ippo-a-ideallab-la-nostra-storia
 lang: en
 description: "How Ippocra started with one project — the Ippo health platform — and discovered Ideallab, the division for custom software and AI for SMEs."
 keywords: ideallab, custom software SMEs, local AI, software consulting, Ippocra, startup pivot, tailored software, Rendiconto, data privacy

--- a/_posts/it/2026-05-25-da-ippo-a-ideallab-la-nostra-storia.md
+++ b/_posts/it/2026-05-25-da-ippo-a-ideallab-la-nostra-storia.md
@@ -1,7 +1,6 @@
 ---
 title: "Da Ippo a Ideallab: la storia di come abbiamo trovato la nostra direzione"
 categories: news
-permalink: /da-ippo-a-ideallab-la-nostra-storia
 lang: it
 description: "Come Ippocra è nata con un solo progetto — la piattaforma sanitaria Ippo — e ha scoperto Ideallab, la divisione per software personalizzato e AI per le PMI."
 keywords: ideallab, software personalizzato PMI, AI locale, consulenza software, Ippocra, startup pivot, software su misura, Rendiconto, privacy dati
@@ -15,7 +14,7 @@ classes: wide
   <img src="/assets/images/screenshots/ideallab-intro.webp" alt="Ideallab — Software Personalizzato & AI per PMI" style="max-width:800px;width:100%;border-radius:12px;box-shadow:0 4px 24px rgba(15,59,46,0.12);margin:1.5rem 0;"/>
 </p>
 
-Ippocra oggi ha due sezioni: [**Ippo**](https://app.ideallab.org), la piattaforma sanitaria per le famiglie, e [**Ideallab**](https://ideallab.org), la consulenza software e AI per le imprese.
+Ippocra oggi ha due sezioni: [**Ippo**](https://app.ippocra.com), la piattaforma sanitaria per le famiglie, e [**Ideallab**](https://ideallab.org), la consulenza software e AI per le imprese.
 
 Ma non è sempre stato così.
 


### PR DESCRIPTION
## Fixes

- **Remove conflicting permalink** from both English and Italian posts — both had  which caused the English post URL to serve Italian content
- **Rename English post slug** from  to  for a proper English URL
- **Fix Italian post Ippo URL** — was pointing to  (wrong), corrected to 

## Resulting URLs

- Italian: 
- English: 