### PR TITLE
fix: resolve English post routing conflict and fix Italian post Ippo link

### DIFF
--- a/_posts/en/2026-05-25-da-ippo-a-ideallab-la-nostra-storia.md
+++ b/_posts/en/2026-05-25-da-ippo-a-ideallab-la-nostra-storia.md
@@ -1,7 +1,7 @@
 ---
 title: "From Ippo to Ideallab: How We Found Our Direction"
 categories: news
-permalink: /da-ippo-a-ideallab-la-nostra-storia
+permalink: /from-ippo-to-ideallab
 lang: en
 description: "How Ippocra started with one project — the Ippo health platform — and discovered Ideallab, the division for custom software and AI for SMEs."
 keywords: ideallab, custom software SMEs, local AI, software consulting, Ippocra, startup pivot, tailored software, Rendiconto, data privacy

--- a/_posts/it/2026-05-25-da-ippo-a-ideallab-la-nostra-storia.md
+++ b/_posts/it/2026-05-25-da-ippo-a-ideallab-la-nostra-storia.md
@@ -15,7 +15,7 @@ classes: wide
   <img src="/assets/images/screenshots/ideallab-intro.webp" alt="Ideallab — Software Personalizzato & AI per PMI" style="max-width:800px;width:100%;border-radius:12px;box-shadow:0 4px 24px rgba(15,59,46,0.12);margin:1.5rem 0;"/>
 </p>
 
-Ippocra oggi ha due sezioni: [**Ippo**](https://app.ideallab.org), la piattaforma sanitaria per le famiglie, e [**Ideallab**](https://ideallab.org), la consulenza software e AI per le imprese.
+Ippocra oggi ha due sezioni: [**Ippo**](https://app.ippocra.com), la piattaforma sanitaria per le famiglie, e [**Ideallab**](https://ideallab.org), la consulenza software e AI per le imprese.
 
 Ma non è sempre stato così.
 


### PR DESCRIPTION
## Problem

PR #69 introduced two blog posts (Italian and English) about Ideallab, but had two issues:

1. **Routing conflict**: Both EN and IT posts had the same permalink `/da-ippo-a-ideallab-la-nostra-storia` — the English post URL served Italian content
2. **Wrong Ippo URL**: Italian post linked to `app.ideallab.org` instead of `app.ippocra.com`

## Fix

- **EN post**: Changed permalink to `/from-ippo-to-ideallab` (English slug matching the title)
- **IT post**: Kept permalink `/da-ippo-a-ideallab-la-nostra-storia` (Italian slug)
- Both files keep the same name for polyglot pairing
- **IT post**: Fixed Ippo link from `app.ideallab.org` → `app.ippocra.com`

## Resulting URLs

- Italian: `/2026/05/25/da-ippo-a-ideallab-la-nostra-storia/`
- English: `/2026/05/25/from-ippo-to-ideallab/`

Each language gets its own correctly-labeled slug. The EN screenshot (`ideallab-intro-en.webp`) was already taken from the English Ideallab homepage — the routing was just broken so it never showed correctly.