### PR TITLE
fix: add excerpt frontmatter to last two blog posts

### DIFF
--- a/_posts/en/2026-04-16-studio-editor-write-preview-every-medical-report.md
+++ b/_posts/en/2026-04-16-studio-editor-write-preview-every-medical-report.md
@@ -1,6 +1,7 @@
 ---
 title: "Ippocra Studio Editor: Write, Preview and Brand Every Medical Report"
 categories: news
+excerpt: "Discover the Ippocra Studio Editor — a professional environment for writing medical reports with live PDF preview, branded letterheads and specialty templates."
 permalink: /studio-editor-write-preview-every-medical-report
 lang: en
 description: "Discover the Ippocra Studio Editor — a professional document editor for doctors with live PDF preview, branded letterheads, specialty templates and DICOM support."

--- a/_posts/en/2026-05-25-da-ippo-a-ideallab-la-nostra-storia.md
+++ b/_posts/en/2026-05-25-da-ippo-a-ideallab-la-nostra-storia.md
@@ -1,6 +1,7 @@
 ---
 title: "From Ippo to Ideallab: How We Found Our Direction"
 categories: news
+excerpt: "Ippocra has two sections: Ippo, the health platform for families, and Ideallab, software and AI consulting for SMEs. Discover how this evolution happened."
 permalink: /from-ippo-to-ideallab
 lang: en
 description: "How Ippocra started with one project — the Ippo health platform — and discovered Ideallab, the division for custom software and AI for SMEs."

--- a/_posts/it/2026-04-16-studio-editor-scrivi-visualizza-anteprima-ogni-referto.md
+++ b/_posts/it/2026-04-16-studio-editor-scrivi-visualizza-anteprima-ogni-referto.md
@@ -1,6 +1,7 @@
 ---
 title: "Ippocra Studio Editor: Scrivi, Visualizza in Anteprima e Condividi Ogni Referto"
 categories: news
+excerpt: "Scopri il nuovo Studio Editor di Ippocra: un ambiente professionale per scrivere referti medici con anteprima PDF live, intestazioni personalizzate e modelli per specialità."
 permalink: /studio-editor-scrivi-visualizza-anteprima-ogni-referto
 lang: it
 description: "Scopri il nuovo Studio Editor di Ippocra: editor professionale per medici con anteprima PDF in tempo reale, intestazioni personalizzate, modelli per specialità e supporto DICOM."

--- a/_posts/it/2026-05-25-da-ippo-a-ideallab-la-nostra-storia.md
+++ b/_posts/it/2026-05-25-da-ippo-a-ideallab-la-nostra-storia.md
@@ -1,6 +1,7 @@
 ---
 title: "Da Ippo a Ideallab: la storia di come abbiamo trovato la nostra direzione"
 categories: news
+excerpt: "Ippocra ha due sezioni: Ippo, la piattaforma sanitaria per le famiglie, e Ideallab, la consulenza software e AI per le PMI. Scopri come è nata questa evoluzione."
 permalink: /da-ippo-a-ideallab-la-nostra-storia
 lang: it
 description: "Come Ippocra è nata con un solo progetto — la piattaforma sanitaria Ippo — e ha scoperto Ideallab, la divisione per software personalizzato e AI per le PMI."


### PR DESCRIPTION
## Problema

Le ultime due pubblicazioni del blog non mostravano un riassunto (excerpt) nella pagina degli articoli, mentre tutte le altre sì.

### Causa

Le ultime due post hanno un'immagine HTML come primo blocco di contenuto (dopo il frontmatter). Jekyll, quando genera l'excerpt automatico, non riesce a estrarre un testo significativo perché il primo blocco è un'immagine. Di conseguenza, nella pagina `/posts/` i post appaiono senza riassunto.

### Fix

Aggiunto il campo `excerpt:` nel frontmatter di entrambi i post (IT + EN) per fornire un riassunto esplicito da mostrare nella lista degli articoli.

### File modificati
- `_posts/it/2026-05-25-da-ippo-a-ideallab-la-nostra-storia.md` — excerpt aggiunto
- `_posts/en/2026-05-25-da-ippo-a-ideallab-la-nostra-storia.md` — excerpt aggiunto
- `_posts/it/2026-04-16-studio-editor-scrivi-visualizza-anteprima-ogni-referto.md` — excerpt aggiunto
- `_posts/en/2026-04-16-studio-editor-write-preview-every-medical-report.md` — excerpt aggiunto
