### PR TITLE
refactor: promote ILAI as featured product on home page

### DIFF
--- a/_includes/masthead-gateway.html
+++ b/_includes/masthead-gateway.html
@@ -25,7 +25,13 @@
         </li>
       <!-- END: Insert for language switching -->
 
-        <!-- Gateway nav: Ideallab + Ippo -->
+        <!-- Gateway nav: ILAI, Ideallab, Ippo -->
+        <li class="masthead__menu-item">
+          <a href="https://ilai.ippocra.com/{{ site.active_lang == 'en' ? 'en' : 'it' }}/" target="_blank" rel="noopener">
+            ILAI <i class="fas fa-external-link-alt" style="font-size:0.7em; margin-left:2px;"></i>
+          </a>
+        </li>
+
         <li class="masthead__menu-item">
           <a href="https://ideallab.org{% if site.active_lang != 'it' %}/{% if site.active_lang %}{{ site.active_lang }}{% endif %}{% endif %}" target="_blank" rel="noopener">
             Ideallab <i class="fas fa-external-link-alt" style="font-size:0.7em; margin-left:2px;"></i>

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -27,6 +27,13 @@
 
         <li class="masthead__menu-item">
           <a
+            href="https://ilai.ippocra.com/{{ site.active_lang == 'en' ? 'en' : 'it' }}/"
+            target="_blank" rel="noopener noreferrer"
+          >ILAI</a>
+        </li>
+
+        <li class="masthead__menu-item">
+          <a
           href="{{ site.data[site.active_lang].strings.navigation.security.url | relative_url }}"
               >{{ site.data[site.active_lang].strings.navigation.security.title }}</a>
         </li>

--- a/_pages/en/_inner_gateway.html
+++ b/_pages/en/_inner_gateway.html
@@ -233,14 +233,14 @@
         transform: translateX(3px);
     }
 
-    /* ---- IDEALLAB: WARM CHARCOAL CARD (bottom row) ---- */
+    /* ---- IDEALLAB: WARM SEPIA CARD (bottom row) ---- */
     .gateway-card-ideallab {
-        background: #1a1610;
+        background: #3b2e20;
         border: 2px solid #c4944a;
         color: #e8ddd0;
     }
     .gateway-card-ideallab:hover {
-        box-shadow: 0 8px 32px rgba(196, 148, 74, 0.25);
+        box-shadow: 0 8px 32px rgba(196, 148, 74, 0.2);
     }
     .gateway-card-ideallab .gateway-brand-kicker {
         color: #c4944a;

--- a/_pages/en/_inner_gateway.html
+++ b/_pages/en/_inner_gateway.html
@@ -7,57 +7,68 @@
         <div class="container mx-auto px-4 sm:px-6 lg:px-8">
             <div class="text-center mt-16 mb-12">
                 <h1 class="page-title" style="font-size:2.5rem;">
-                     <span style="color:#2e7d88;">Ippocra</span>: two areas, one approach
+                     <span style="color:#2e7d88;">Ippocra</span>: own your company data, your own AI
                  </h1>
                 <p class="paragraph-lg mt-4" style="color:#555; max-width:600px; margin-left:auto; margin-right:auto;">
-                    We build software that adapts to people — whether it's for your family's health or for your business.
+                    We build software that adapts to your business — a local AI that handles your documents, learns your workflow, and lives on your machine.
                 </p>
             </div>
 
-            <!-- Two Cards -->
-            <div class="max-w-4xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-6 mb-16">
-
-                <!-- Card IDEALLAB — DARK CARD -->
-                <div class="gateway-card gateway-card-ideallab">
-                    <div class="gateway-brand gateway-brand-ideallab">
-                        <div class="gateway-brand-mark gateway-brand-mark-ideallab" aria-hidden="true">
+            <!-- ILAI Card — FEATURED DARK CARD -->
+            <div class="max-w-3xl mx-auto mb-16">
+                <div class="gateway-card gateway-card-ilai featured-glow">
+                    <div class="featured-badge">Ippocra Product</div>
+                    <div class="gateway-brand gateway-brand-ilai">
+                        <div class="gateway-brand-mark gateway-brand-mark-ilai" aria-hidden="true">
                             <img src="{{ '/assets/images/il-logo.svg' | relative_url }}" alt="ILAI" style="width:3.25rem; height:3.25rem; object-fit:contain;">
                         </div>
                         <div class="gateway-brand-copy">
-                            <p class="gateway-brand-kicker">Ideallab</p>
-                            <p class="gateway-brand-subtitle">Local AI</p>
+                            <p class="gateway-brand-kicker">ILAI</p>
+                            <p class="gateway-brand-subtitle">Ippocra Local Artificial Intelligence</p>
                         </div>
                     </div>
-                    <h2 class="mt-0" style="font-size:1.75rem; color:#4dd0c4;">
-                        Ideallab
+                    <h2 class="mt-0" style="font-size:2rem; color:#4dd0c4;">
+                        ILAI
                     </h2>
                     <p class="mt-3 paragraph-md" style="color:#c8d9d5;">
-                        Custom software and <strong>ILAI</strong>: Ideallab Local AI for SMEs.
-                        Your data never leaves your control.
+                        Your local AI colleague. Handles confidential documents, learns your workflow, and grows with your company.
+                        <strong>Zero cloud, zero lock-in, zero hidden costs.</strong>
                     </p>
                     <ul class="mt-4 space-y-2" style="text-align:left;">
                         <li style="display:flex; align-items:flex-start; gap:0.5rem;">
                             <i class="fas fa-check-circle" style="color:#4dd0c4; margin-top:4px;"></i>
-                            <span>ILAI: local AI, zero lock-in, zero cloud</span>
+                            <span><strong>Confidential documents</strong> stay inside your network — never in the cloud</span>
                         </li>
                         <li style="display:flex; align-items:flex-start; gap:0.5rem;">
                             <i class="fas fa-check-circle" style="color:#4dd0c4; margin-top:4px;"></i>
-                            <span>Custom software for your business</span>
+                            <span><strong>Workflow</strong> that gets better over time — you teach it, it doesn't replace it</span>
                         </li>
                         <li style="display:flex; align-items:flex-start; gap:0.5rem;">
                             <i class="fas fa-check-circle" style="color:#4dd0c4; margin-top:4px;"></i>
-                            <span>Practical AI consulting</span>
+                            <span><strong>Predictable costs</strong> — clear investment, no surprise bills</span>
+                        </li>
+                        <li style="display:flex; align-items:flex-start; gap:0.5rem;">
+                            <i class="fas fa-check-circle" style="color:#4dd0c4; margin-top:4px;"></i>
+                            <span><strong>Asset that grows</strong> — the more you use it, the more competitive advantage you gain</span>
                         </li>
                     </ul>
-                    <a href="https://ideallab.org/en/" target="_blank" rel="noopener noreferrer"
-                        class="gateway-card-cta gateway-card-cta-ideallab">
-                        Visit Ideallab
+                    <a href="https://ilai.ippocra.com/en/" target="_blank" rel="noopener noreferrer"
+                        class="gateway-card-cta gateway-card-cta-ilai">
+                        Discover ILAI
                         <i class="fas fa-arrow-right ml-2"></i>
                     </a>
-                    <p class="mt-2 text-xs" style="color:#7a9a95;">ideallab.org</p>
+                    <p class="mt-2 text-xs" style="color:#7a9a95;">ilai.ippocra.com</p>
                 </div>
+            </div>
 
-                <!-- Card IPPO — LIGHT CARD -->
+            <!-- Ideallab one-liner -->
+            <p class="text-center mb-12" style="color:#666; font-size:1.05rem;">
+                Ideallab — tailored software for businesses that want to grow.
+                <a href="https://ideallab.org/en/" target="_blank" rel="noopener noreferrer" style="color:#2e7d88; text-decoration:underline;">Learn more →</a>
+            </p>
+
+            <!-- Ippo Card — LIGHT CARD -->
+            <div class="max-w-3xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-6 mb-16">
                 <div class="gateway-card gateway-card-ippo">
                     <div class="gateway-brand gateway-brand-ippo">
                         <div class="gateway-brand-mark gateway-brand-mark-ippo" aria-hidden="true">
@@ -95,21 +106,27 @@
                     <p class="mt-2 text-xs" style="color:#888;">ippocra.com/ippo</p>
                 </div>
 
-            </div>
-
-            <!-- Trust badges -->
-            <div class="flex flex-wrap justify-center gap-6 mt-4">
-                <div class="flex items-center gap-2 px-4 py-2 rounded-full border" style="border-color:#2e7d88; color:#2e7d88;">
-                    <i class="fas fa-shield-alt"></i>
-                    <span class="font-semibold text-sm">GDPR Compliant</span>
-                </div>
-                <div class="flex items-center gap-2 px-4 py-2 rounded-full border" style="border-color:#2e7d88; color:#2e7d88;">
-                    <i class="fas fa-lock"></i>
-                    <span class="font-semibold text-sm">Privacy First</span>
-                </div>
-                <div class="flex items-center gap-2 px-4 py-2 rounded-full border" style="border-color:#2e7d88; color:#2e7d88;">
-                    <i class="fas fa-building"></i>
-                    <span class="font-semibold text-sm">Innovative Startup</span>
+                <!-- Trust badges card -->
+                <div class="gateway-card gateway-card-trust">
+                    <h3 style="font-size:1.1rem; color:#555; margin-bottom:1rem;">Why Ippocra</h3>
+                    <div class="flex flex-col gap-3">
+                        <div class="flex items-center gap-2">
+                            <i class="fas fa-shield-alt" style="color:#2e7d88;"></i>
+                            <span class="font-semibold text-sm" style="color:#333;">GDPR Compliant</span>
+                        </div>
+                        <div class="flex items-center gap-2">
+                            <i class="fas fa-lock" style="color:#2e7d88;"></i>
+                            <span class="font-semibold text-sm" style="color:#333;">Privacy First</span>
+                        </div>
+                        <div class="flex items-center gap-2">
+                            <i class="fas fa-building" style="color:#2e7d88;"></i>
+                            <span class="font-semibold text-sm" style="color:#333;">Innovative Startup</span>
+                        </div>
+                    </div>
+                    <div style="margin-top:1.5rem; padding-top:1rem; border-top:1px solid #e0e7e6;">
+                        <p style="font-size:0.85rem; color:#888; margin:0;">Contact us</p>
+                        <a href="mailto:info@ippocra.com" style="color:#2e7d88; text-decoration:none; font-weight:600;">info@ippocra.com</a>
+                    </div>
                 </div>
             </div>
         </div>
@@ -128,41 +145,61 @@
         transition: transform 0.2s, box-shadow 0.2s;
         display: flex;
         flex-direction: column;
+        position: relative;
     }
     .gateway-card:hover {
         transform: translateY(-2px);
     }
 
-    /* ---- IDEALLAB: DARK CARD (black bg, teal text) ---- */
-    .gateway-card-ideallab {
+    /* ---- Featured badge for ILAI ---- */
+    .featured-badge {
+        display: inline-block;
+        background: #2e7d88;
+        color: #ffffff;
+        font-size: 0.7rem;
+        font-weight: 700;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        padding: 4px 14px;
+        border-radius: 999px;
+        margin-bottom: 1rem;
+    }
+
+    /* ---- Featured glow effect ---- */
+    .featured-glow {
+        box-shadow: 0 4px 20px rgba(46, 125, 136, 0.12);
+    }
+    .featured-glow:hover {
+        box-shadow: 0 8px 40px rgba(46, 125, 136, 0.35);
+    }
+
+    /* ---- ILAI: FEATURED DARK CARD ---- */
+    .gateway-card-ilai {
         background: #0e0e10;
         border: 2px solid #2e7d88;
         color: #e0e8e6;
     }
-    .gateway-card-ideallab:hover {
-        box-shadow: 0 8px 32px rgba(46, 125, 136, 0.3);
-    }
-    .gateway-card-ideallab .gateway-brand-kicker {
+    .gateway-card-ilai .gateway-brand-kicker {
         color: #8aa8a2;
     }
-    .gateway-card-ideallab .gateway-brand-subtitle {
+    .gateway-card-ilai .gateway-brand-subtitle {
         color: #c8d9d5;
     }
-    .gateway-card-ideallab .gateway-brand-mark-ideallab {
+    .gateway-card-ilai .gateway-brand-mark-ilai {
         background: transparent;
         box-shadow: none;
     }
-    .gateway-card-ideallab .gateway-card-cta-ideallab {
+    .gateway-card-ilai .gateway-card-cta-ilai {
         background: #2e7d88;
         color: #ffffff;
     }
-    .gateway-card-ideallab .gateway-card-cta-ideallab:hover {
+    .gateway-card-ilai .gateway-card-cta-ilai:hover {
         background: #4dd0c4;
         color: #0e0e10;
         transform: translateX(3px);
     }
 
-    /* ---- IPPO: LIGHT CARD (white bg, teal accents) ---- */
+    /* ---- IPPO: LIGHT CARD ---- */
     .gateway-card-ippo {
         background: #ffffff;
         border: 2px solid #e0e7e6;
@@ -186,7 +223,18 @@
         transform: translateX(3px);
     }
 
-    /* ---- SHARED: brand mark ---- */
+    /* ---- Trust card ---- */
+    .gateway-card-trust {
+        background: #ffffff;
+        border: 2px solid #e0e7e6;
+        box-shadow: 0 2px 8px rgba(46, 125, 136, 0.06);
+    }
+    .gateway-card-trust:hover {
+        box-shadow: 0 8px 24px rgba(46, 125, 136, 0.12);
+        border-color: #2e7d88;
+    }
+
+    /* ---- Shared: brand mark ---- */
     .gateway-brand {
         display: flex;
         align-items: center;

--- a/_pages/en/_inner_gateway.html
+++ b/_pages/en/_inner_gateway.html
@@ -61,73 +61,70 @@
                 </div>
             </div>
 
-            <!-- Ideallab one-liner -->
-            <p class="text-center mb-12" style="color:#666; font-size:1.05rem;">
-                Ideallab — tailored software for businesses that want to grow.
-                <a href="https://ideallab.org/en/" target="_blank" rel="noopener noreferrer" style="color:#2e7d88; text-decoration:underline;">Learn more →</a>
+            <!-- Three-card row: ILAI · Ippo · Ideallab -->
+            <p class="text-center mb-6" style="color:#888; font-size:0.9rem; text-transform:uppercase; letter-spacing:0.08em; font-weight:600;">
+                Our Products
             </p>
+            <div class="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-6 mb-16">
 
-            <!-- Ippo Card — LIGHT CARD -->
-            <div class="max-w-3xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-6 mb-16">
+                <!-- Compact ILAI card -->
+                <div class="gateway-card gateway-card-ilai-compact">
+                    <div class="gateway-brand gateway-brand-ilai-compact">
+                        <div class="gateway-brand-mark gateway-brand-mark-ilai" aria-hidden="true" style="width:2.75rem; height:2.75rem; border-radius:0.75rem;">
+                            <img src="{{ '/assets/images/il-logo.svg' | relative_url }}" alt="ILAI" style="width:2.25rem; height:2.25rem; object-fit:contain;">
+                        </div>
+                        <div class="gateway-brand-copy">
+                            <p class="gateway-brand-kicker" style="color:#8aa8a2;">ILAI</p>
+                        </div>
+                    </div>
+                    <p class="paragraph-sm" style="color:#c8d9d5; margin:0 0 1rem;">
+                        Local AI for businesses. Confidential data, zero lock-in, zero cloud.
+                    </p>
+                    <a href="https://ilai.ippocra.com/en/" target="_blank" rel="noopener noreferrer"
+                        class="gateway-card-cta gateway-card-cta-ilai gateway-card-cta-sm">
+                        Go to ILAI <i class="fas fa-arrow-right ml-1"></i>
+                    </a>
+                </div>
+
+                <!-- Ippo card -->
                 <div class="gateway-card gateway-card-ippo">
                     <div class="gateway-brand gateway-brand-ippo">
-                        <div class="gateway-brand-mark gateway-brand-mark-ippo" aria-hidden="true">
-                            <img src="{{ '/assets/images/ippo-mascot.png' | relative_url }}" alt="Ippo" style="width:3.5rem; height:auto; border-radius:0.75rem;">
+                        <div class="gateway-brand-mark gateway-brand-mark-ippo" aria-hidden="true" style="width:2.75rem; height:2.75rem; border-radius:0.75rem;">
+                            <img src="{{ '/assets/images/ippo-mascot.png' | relative_url }}" alt="Ippo" style="width:2.75rem; height:2.75rem; object-fit:contain;">
                         </div>
                         <div class="gateway-brand-copy">
                             <p class="gateway-brand-kicker">Ippo</p>
                             <p class="gateway-brand-subtitle">Health platform</p>
                         </div>
                     </div>
-                    <h2 style="font-size:1.75rem; color:#2e7d88;">
-                        Ippo
-                    </h2>
-                    <p class="mt-3 paragraph-md" style="color:#4f5b62;">
+                    <p class="paragraph-sm" style="color:#4f5b62; margin:0 0 1rem;">
                         The digital health platform for families. Organize, find and share medical reports securely.
                     </p>
-                    <ul class="mt-4 space-y-2" style="text-align:left;">
-                        <li style="display:flex; align-items:flex-start; gap:0.5rem;">
-                            <i class="fas fa-check-circle" style="color:#2e7d88; margin-top:4px;"></i>
-                            <span>All health documents in one place</span>
-                        </li>
-                        <li style="display:flex; align-items:flex-start; gap:0.5rem;">
-                            <i class="fas fa-check-circle" style="color:#2e7d88; margin-top:4px;"></i>
-                            <span>Smart search and health timeline</span>
-                        </li>
-                        <li style="display:flex; align-items:flex-start; gap:0.5rem;">
-                            <i class="fas fa-check-circle" style="color:#2e7d88; margin-top:4px;"></i>
-                            <span>Secure sharing with doctors</span>
-                        </li>
-                    </ul>
-                    <a href="/en/ippo" class="gateway-card-cta gateway-card-cta-ippo">
-                        Discover Ippo
-                        <i class="fas fa-arrow-right ml-2"></i>
+                    <a href="/en/ippo" class="gateway-card-cta gateway-card-cta-ippo gateway-card-cta-sm">
+                        Go to Ippo <i class="fas fa-arrow-right ml-1"></i>
                     </a>
-                    <p class="mt-2 text-xs" style="color:#888;">ippocra.com/ippo</p>
                 </div>
 
-                <!-- Trust badges card -->
-                <div class="gateway-card gateway-card-trust">
-                    <h3 style="font-size:1.1rem; color:#555; margin-bottom:1rem;">Why Ippocra</h3>
-                    <div class="flex flex-col gap-3">
-                        <div class="flex items-center gap-2">
-                            <i class="fas fa-shield-alt" style="color:#2e7d88;"></i>
-                            <span class="font-semibold text-sm" style="color:#333;">GDPR Compliant</span>
+                <!-- Ideallab card -->
+                <div class="gateway-card gateway-card-ideallab">
+                    <div class="gateway-brand gateway-brand-ideallab">
+                        <div class="gateway-brand-mark gateway-brand-mark-ideallab" aria-hidden="true" style="width:2.75rem; height:2.75rem; border-radius:0.75rem;">
+                            <img src="{{ '/assets/images/il-logo.svg' | relative_url }}" alt="Ideallab" style="width:2.25rem; height:2.25rem; object-fit:contain;">
                         </div>
-                        <div class="flex items-center gap-2">
-                            <i class="fas fa-lock" style="color:#2e7d88;"></i>
-                            <span class="font-semibold text-sm" style="color:#333;">Privacy First</span>
-                        </div>
-                        <div class="flex items-center gap-2">
-                            <i class="fas fa-building" style="color:#2e7d88;"></i>
-                            <span class="font-semibold text-sm" style="color:#333;">Innovative Startup</span>
+                        <div class="gateway-brand-copy">
+                            <p class="gateway-brand-kicker" style="color:#8aa8a2;">Ideallab</p>
+                            <p class="gateway-brand-subtitle" style="color:#c8d9d5;">Software consulting</p>
                         </div>
                     </div>
-                    <div style="margin-top:1.5rem; padding-top:1rem; border-top:1px solid #e0e7e6;">
-                        <p style="font-size:0.85rem; color:#888; margin:0;">Contact us</p>
-                        <a href="mailto:info@ippocra.com" style="color:#2e7d88; text-decoration:none; font-weight:600;">info@ippocra.com</a>
-                    </div>
+                    <p class="paragraph-sm" style="color:#c8d9d5; margin:0 0 1rem;">
+                        Custom software for SMEs. Consulting, development, and tailored solutions.
+                    </p>
+                    <a href="https://ideallab.org/en/" target="_blank" rel="noopener noreferrer"
+                        class="gateway-card-cta gateway-card-cta-ideallab gateway-card-cta-sm">
+                        Go to Ideallab <i class="fas fa-arrow-right ml-1"></i>
+                    </a>
                 </div>
+
             </div>
         </div>
     </section>
@@ -199,6 +196,19 @@
         transform: translateX(3px);
     }
 
+    /* ---- Compact ILAI (bottom row) ---- */
+    .gateway-card-ilai-compact {
+        background: #0e0e10;
+        border: 2px solid #2e7d88;
+        color: #e0e8e6;
+    }
+    .gateway-card-ilai-compact:hover {
+        box-shadow: 0 8px 32px rgba(46, 125, 136, 0.3);
+    }
+    .gateway-card-ilai-compact .gateway-brand-kicker {
+        color: #8aa8a2;
+    }
+
     /* ---- IPPO: LIGHT CARD ---- */
     .gateway-card-ippo {
         background: #ffffff;
@@ -223,15 +233,33 @@
         transform: translateX(3px);
     }
 
-    /* ---- Trust card ---- */
-    .gateway-card-trust {
-        background: #ffffff;
-        border: 2px solid #e0e7e6;
-        box-shadow: 0 2px 8px rgba(46, 125, 136, 0.06);
+    /* ---- IDEALLAB: DARK CARD (bottom row) ---- */
+    .gateway-card-ideallab {
+        background: #0e0e10;
+        border: 2px solid #2e7d88;
+        color: #e0e8e6;
     }
-    .gateway-card-trust:hover {
-        box-shadow: 0 8px 24px rgba(46, 125, 136, 0.12);
-        border-color: #2e7d88;
+    .gateway-card-ideallab:hover {
+        box-shadow: 0 8px 32px rgba(46, 125, 136, 0.3);
+    }
+    .gateway-card-ideallab .gateway-brand-kicker {
+        color: #8aa8a2;
+    }
+    .gateway-card-ideallab .gateway-brand-subtitle {
+        color: #c8d9d5;
+    }
+    .gateway-card-ideallab .gateway-brand-mark-ideallab {
+        background: transparent;
+        box-shadow: none;
+    }
+    .gateway-card-ideallab .gateway-card-cta-ideallab {
+        background: #2e7d88;
+        color: #ffffff;
+    }
+    .gateway-card-ideallab .gateway-card-cta-ideallab:hover {
+        background: #4dd0c4;
+        color: #0e0e10;
+        transform: translateX(3px);
     }
 
     /* ---- Shared: brand mark ---- */
@@ -280,6 +308,10 @@
         font-weight: 600;
         text-decoration: none;
         transition: all 0.2s;
+    }
+    .gateway-card-cta-sm {
+        padding: 0.6rem 1.25rem;
+        font-size: 0.9rem;
     }
     .gateway-card-cta:hover {
         text-decoration: none;

--- a/_pages/en/_inner_gateway.html
+++ b/_pages/en/_inner_gateway.html
@@ -109,14 +109,14 @@
                 <div class="gateway-card gateway-card-ideallab">
                     <div class="gateway-brand gateway-brand-ideallab">
                         <div class="gateway-brand-mark gateway-brand-mark-ideallab" aria-hidden="true" style="width:2.75rem; height:2.75rem; border-radius:0.75rem;">
-                            <img src="{{ '/assets/images/il-logo.svg' | relative_url }}" alt="Ideallab" style="width:2.25rem; height:2.25rem; object-fit:contain;">
+                            <img src="{{ '/assets/ideallab-favicon.svg' | relative_url }}" alt="Ideallab" style="width:2.25rem; height:2.25rem; object-fit:contain;">
                         </div>
                         <div class="gateway-brand-copy">
-                            <p class="gateway-brand-kicker" style="color:#8aa8a2;">Ideallab</p>
-                            <p class="gateway-brand-subtitle" style="color:#c8d9d5;">Software consulting</p>
+                            <p class="gateway-brand-kicker" style="color:#c4944a;">Ideallab</p>
+                            <p class="gateway-brand-subtitle" style="color:#d4c4a8;">Software consulting</p>
                         </div>
                     </div>
-                    <p class="paragraph-sm" style="color:#c8d9d5; margin:0 0 1rem;">
+                    <p class="paragraph-sm" style="color:#d4c4a8; margin:0 0 1rem;">
                         Custom software for SMEs. Consulting, development, and tailored solutions.
                     </p>
                     <a href="https://ideallab.org/en/" target="_blank" rel="noopener noreferrer"
@@ -133,7 +133,7 @@
 
 <style>
     .gateway-hero-bg {
-        background: linear-gradient(135deg, #f8fffe 0%, #f0f7fa 50%, #fafafa 100%);
+        background: linear-gradient(135deg, #fafafa 0%, #f5f0e8 50%, #fafafa 100%);
         padding: 0 0 4rem;
     }
     .gateway-card {

--- a/_pages/en/_inner_gateway.html
+++ b/_pages/en/_inner_gateway.html
@@ -233,33 +233,36 @@
         transform: translateX(3px);
     }
 
-    /* ---- IDEALLAB: DARK CARD (bottom row) ---- */
+    /* ---- IDEALLAB: AMBER DARK CARD (bottom row) ---- */
     .gateway-card-ideallab {
         background: #0e0e10;
-        border: 2px solid #2e7d88;
-        color: #e0e8e6;
+        border: 2px solid #c4944a;
+        color: #e8ddd0;
     }
     .gateway-card-ideallab:hover {
-        box-shadow: 0 8px 32px rgba(46, 125, 136, 0.3);
+        box-shadow: 0 8px 32px rgba(196, 148, 74, 0.3);
     }
     .gateway-card-ideallab .gateway-brand-kicker {
-        color: #8aa8a2;
+        color: #c4944a;
     }
     .gateway-card-ideallab .gateway-brand-subtitle {
-        color: #c8d9d5;
+        color: #d4c4a8;
     }
     .gateway-card-ideallab .gateway-brand-mark-ideallab {
         background: transparent;
         box-shadow: none;
     }
     .gateway-card-ideallab .gateway-card-cta-ideallab {
-        background: #2e7d88;
-        color: #ffffff;
+        background: #c4944a;
+        color: #0e0e10;
     }
     .gateway-card-ideallab .gateway-card-cta-ideallab:hover {
-        background: #4dd0c4;
+        background: #d4a85a;
         color: #0e0e10;
         transform: translateX(3px);
+    }
+    .gateway-card-ideallab .paragraph-sm {
+        color: #d4c4a8;
     }
 
     /* ---- Shared: brand mark ---- */

--- a/_pages/en/_inner_gateway.html
+++ b/_pages/en/_inner_gateway.html
@@ -233,14 +233,14 @@
         transform: translateX(3px);
     }
 
-    /* ---- IDEALLAB: AMBER DARK CARD (bottom row) ---- */
+    /* ---- IDEALLAB: WARM CHARCOAL CARD (bottom row) ---- */
     .gateway-card-ideallab {
-        background: #0e0e10;
+        background: #1a1610;
         border: 2px solid #c4944a;
         color: #e8ddd0;
     }
     .gateway-card-ideallab:hover {
-        box-shadow: 0 8px 32px rgba(196, 148, 74, 0.3);
+        box-shadow: 0 8px 32px rgba(196, 148, 74, 0.25);
     }
     .gateway-card-ideallab .gateway-brand-kicker {
         color: #c4944a;

--- a/_pages/en/home.md
+++ b/_pages/en/home.md
@@ -2,12 +2,12 @@
 layout: landing_page
 lang: en
 permalink: /
-title: "Ippocra — two areas, one approach"
+title: "Ippocra — own your company data, your own AI"
 redirect_from:
     - /customers
 markdown: false
-description: "Ippocra: two complementary businesses, one team. Ideallab — custom software and local AI for businesses. Ippo — digital health platform for families."
-keywords: "Ippocra, Ideallab, ILAI, local AI, custom software, Ippo, digital health, family health documents"
+description: "Ippocra: we build local AI for businesses (ILAI) that stays on your machine, and Ippo — digital health platform for families."
+keywords: "Ippocra, ILAI, local AI, Ippo, digital health, family health documents, company data, local artificial intelligence"
 ---
 
 {% include_relative _inner_gateway.html %}

--- a/_pages/it/_inner_gateway.html
+++ b/_pages/it/_inner_gateway.html
@@ -61,73 +61,70 @@
                 </div>
             </div>
 
-            <!-- Ideallab one-liner -->
-            <p class="text-center mb-12" style="color:#666; font-size:1.05rem;">
-                Ideallab — software personalizzato per imprese che vogliono crescere.
-                <a href="https://ideallab.org/it/" target="_blank" rel="noopener noreferrer" style="color:#2e7d88; text-decoration:underline;">Scopri di più →</a>
+            <!-- Three-card row: ILAI · Ippo · Ideallab -->
+            <p class="text-center mb-6" style="color:#888; font-size:0.9rem; text-transform:uppercase; letter-spacing:0.08em; font-weight:600;">
+                I nostri prodotti
             </p>
+            <div class="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-6 mb-16">
 
-            <!-- Ippo Card — LIGHT CARD -->
-            <div class="max-w-3xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-6 mb-16">
+                <!-- Compact ILAI card -->
+                <div class="gateway-card gateway-card-ilai-compact">
+                    <div class="gateway-brand gateway-brand-ilai-compact">
+                        <div class="gateway-brand-mark gateway-brand-mark-ilai" aria-hidden="true" style="width:2.75rem; height:2.75rem; border-radius:0.75rem;">
+                            <img src="{{ '/assets/images/il-logo.svg' | relative_url }}" alt="ILAI" style="width:2.25rem; height:2.25rem; object-fit:contain;">
+                        </div>
+                        <div class="gateway-brand-copy">
+                            <p class="gateway-brand-kicker" style="color:#8aa8a2;">ILAI</p>
+                        </div>
+                    </div>
+                    <p class="paragraph-sm" style="color:#c8d9d5; margin:0 0 1rem;">
+                        AI locale per le imprese. Dati riservati, zero lock-in, zero cloud.
+                    </p>
+                    <a href="https://ilai.ippocra.com/it/" target="_blank" rel="noopener noreferrer"
+                        class="gateway-card-cta gateway-card-cta-ilai gateway-card-cta-sm">
+                        Vai a ILAI <i class="fas fa-arrow-right ml-1"></i>
+                    </a>
+                </div>
+
+                <!-- Ippo card -->
                 <div class="gateway-card gateway-card-ippo">
                     <div class="gateway-brand gateway-brand-ippo">
-                        <div class="gateway-brand-mark gateway-brand-mark-ippo" aria-hidden="true">
-                            <img src="{{ '/assets/images/ippo-mascot.png' | relative_url }}" alt="Ippo" style="width:3.5rem; height:auto; border-radius:0.75rem;">
+                        <div class="gateway-brand-mark gateway-brand-mark-ippo" aria-hidden="true" style="width:2.75rem; height:2.75rem; border-radius:0.75rem;">
+                            <img src="{{ '/assets/images/ippo-mascot.png' | relative_url }}" alt="Ippo" style="width:2.75rem; height:2.75rem; object-fit:contain;">
                         </div>
                         <div class="gateway-brand-copy">
                             <p class="gateway-brand-kicker">Ippo</p>
-                            <p class="gateway-brand-subtitle">Health platform</p>
+                            <p class="gateway-brand-subtitle">Salute digitale</p>
                         </div>
                     </div>
-                    <h2 style="font-size:1.75rem; color:#2e7d88;">
-                        Ippo
-                    </h2>
-                    <p class="mt-3 paragraph-md" style="color:#4f5b62;">
+                    <p class="paragraph-sm" style="color:#4f5b62; margin:0 0 1rem;">
                         La piattaforma per la salute digitale delle famiglie. Organizza, trova e condividi i referti in modo sicuro.
                     </p>
-                    <ul class="mt-4 space-y-2" style="text-align:left;">
-                        <li style="display:flex; align-items:flex-start; gap:0.5rem;">
-                            <i class="fas fa-check-circle" style="color:#2e7d88; margin-top:4px;"></i>
-                            <span>Tutti i documenti sanitari in un unico posto</span>
-                        </li>
-                        <li style="display:flex; align-items:flex-start; gap:0.5rem;">
-                            <i class="fas fa-check-circle" style="color:#2e7d88; margin-top:4px;"></i>
-                            <span>Ricerca intelligente e timeline sanitaria</span>
-                        </li>
-                        <li style="display:flex; align-items:flex-start; gap:0.5rem;">
-                            <i class="fas fa-check-circle" style="color:#2e7d88; margin-top:4px;"></i>
-                            <span>Condivisione sicura con i medici</span>
-                        </li>
-                    </ul>
-                    <a href="/ippo" class="gateway-card-cta gateway-card-cta-ippo">
-                        Scopri Ippo
-                        <i class="fas fa-arrow-right ml-2"></i>
+                    <a href="/ippo" class="gateway-card-cta gateway-card-cta-ippo gateway-card-cta-sm">
+                        Vai a Ippo <i class="fas fa-arrow-right ml-1"></i>
                     </a>
-                    <p class="mt-2 text-xs" style="color:#888;">ippocra.com/ippo</p>
                 </div>
 
-                <!-- Trust badges — moved into their own card -->
-                <div class="gateway-card gateway-card-trust">
-                    <h3 style="font-size:1.1rem; color:#555; margin-bottom:1rem;">Perché Ippocra</h3>
-                    <div class="flex flex-col gap-3">
-                        <div class="flex items-center gap-2">
-                            <i class="fas fa-shield-alt" style="color:#2e7d88;"></i>
-                            <span class="font-semibold text-sm" style="color:#333;">GDPR Compliant</span>
+                <!-- Ideallab card -->
+                <div class="gateway-card gateway-card-ideallab">
+                    <div class="gateway-brand gateway-brand-ideallab">
+                        <div class="gateway-brand-mark gateway-brand-mark-ideallab" aria-hidden="true" style="width:2.75rem; height:2.75rem; border-radius:0.75rem;">
+                            <img src="{{ '/assets/images/il-logo.svg' | relative_url }}" alt="Ideallab" style="width:2.25rem; height:2.25rem; object-fit:contain;">
                         </div>
-                        <div class="flex items-center gap-2">
-                            <i class="fas fa-lock" style="color:#2e7d88;"></i>
-                            <span class="font-semibold text-sm" style="color:#333;">Privacy First</span>
-                        </div>
-                        <div class="flex items-center gap-2">
-                            <i class="fas fa-building" style="color:#2e7d88;"></i>
-                            <span class="font-semibold text-sm" style="color:#333;">Startup Innovativa</span>
+                        <div class="gateway-brand-copy">
+                            <p class="gateway-brand-kicker" style="color:#8aa8a2;">Ideallab</p>
+                            <p class="gateway-brand-subtitle" style="color:#c8d9d5;">Consulenza software</p>
                         </div>
                     </div>
-                    <div style="margin-top:1.5rem; padding-top:1rem; border-top:1px solid #e0e7e6;">
-                        <p style="font-size:0.85rem; color:#888; margin:0;">Contattaci</p>
-                        <a href="mailto:info@ippocra.com" style="color:#2e7d88; text-decoration:none; font-weight:600;">info@ippocra.com</a>
-                    </div>
+                    <p class="paragraph-sm" style="color:#c8d9d5; margin:0 0 1rem;">
+                        Software personalizzato per le PMI. Consulenza, sviluppo e soluzioni su misura.
+                    </p>
+                    <a href="https://ideallab.org/it/" target="_blank" rel="noopener noreferrer"
+                        class="gateway-card-cta gateway-card-cta-ideallab gateway-card-cta-sm">
+                        Vai a Ideallab <i class="fas fa-arrow-right ml-1"></i>
+                    </a>
                 </div>
+
             </div>
         </div>
     </section>
@@ -199,6 +196,19 @@
         transform: translateX(3px);
     }
 
+    /* ---- Compact ILAI (bottom row) ---- */
+    .gateway-card-ilai-compact {
+        background: #0e0e10;
+        border: 2px solid #2e7d88;
+        color: #e0e8e6;
+    }
+    .gateway-card-ilai-compact:hover {
+        box-shadow: 0 8px 32px rgba(46, 125, 136, 0.3);
+    }
+    .gateway-card-ilai-compact .gateway-brand-kicker {
+        color: #8aa8a2;
+    }
+
     /* ---- IPPO: LIGHT CARD ---- */
     .gateway-card-ippo {
         background: #ffffff;
@@ -223,15 +233,33 @@
         transform: translateX(3px);
     }
 
-    /* ---- Trust card ---- */
-    .gateway-card-trust {
-        background: #ffffff;
-        border: 2px solid #e0e7e6;
-        box-shadow: 0 2px 8px rgba(46, 125, 136, 0.06);
+    /* ---- IDEALLAB: DARK CARD (bottom row) ---- */
+    .gateway-card-ideallab {
+        background: #0e0e10;
+        border: 2px solid #2e7d88;
+        color: #e0e8e6;
     }
-    .gateway-card-trust:hover {
-        box-shadow: 0 8px 24px rgba(46, 125, 136, 0.12);
-        border-color: #2e7d88;
+    .gateway-card-ideallab:hover {
+        box-shadow: 0 8px 32px rgba(46, 125, 136, 0.3);
+    }
+    .gateway-card-ideallab .gateway-brand-kicker {
+        color: #8aa8a2;
+    }
+    .gateway-card-ideallab .gateway-brand-subtitle {
+        color: #c8d9d5;
+    }
+    .gateway-card-ideallab .gateway-brand-mark-ideallab {
+        background: transparent;
+        box-shadow: none;
+    }
+    .gateway-card-ideallab .gateway-card-cta-ideallab {
+        background: #2e7d88;
+        color: #ffffff;
+    }
+    .gateway-card-ideallab .gateway-card-cta-ideallab:hover {
+        background: #4dd0c4;
+        color: #0e0e10;
+        transform: translateX(3px);
     }
 
     /* ---- Shared: brand mark ---- */
@@ -280,6 +308,10 @@
         font-weight: 600;
         text-decoration: none;
         transition: all 0.2s;
+    }
+    .gateway-card-cta-sm {
+        padding: 0.6rem 1.25rem;
+        font-size: 0.9rem;
     }
     .gateway-card-cta:hover {
         text-decoration: none;

--- a/_pages/it/_inner_gateway.html
+++ b/_pages/it/_inner_gateway.html
@@ -233,14 +233,14 @@
         transform: translateX(3px);
     }
 
-    /* ---- IDEALLAB: WARM CHARCOAL CARD (bottom row) ---- */
+    /* ---- IDEALLAB: WARM SEPIA CARD (bottom row) ---- */
     .gateway-card-ideallab {
-        background: #1a1610;
+        background: #3b2e20;
         border: 2px solid #c4944a;
         color: #e8ddd0;
     }
     .gateway-card-ideallab:hover {
-        box-shadow: 0 8px 32px rgba(196, 148, 74, 0.25);
+        box-shadow: 0 8px 32px rgba(196, 148, 74, 0.2);
     }
     .gateway-card-ideallab .gateway-brand-kicker {
         color: #c4944a;

--- a/_pages/it/_inner_gateway.html
+++ b/_pages/it/_inner_gateway.html
@@ -41,7 +41,7 @@
                         </li>
                         <li style="display:flex; align-items:flex-start; gap:0.5rem;">
                             <i class="fas fa-check-circle" style="color:#4dd0c4; margin-top:4px;"></i>
-                            <span><strong>Workflow</strong> che migliora nel tempo — non lo sostituisci, lo insegni</span>
+                            <span><strong>Workflow</strong> che migliora nel tempo — non lo sostituisci, lo migliori</span>
                         </li>
                         <li style="display:flex; align-items:flex-start; gap:0.5rem;">
                             <i class="fas fa-check-circle" style="color:#4dd0c4; margin-top:4px;"></i>

--- a/_pages/it/_inner_gateway.html
+++ b/_pages/it/_inner_gateway.html
@@ -109,14 +109,14 @@
                 <div class="gateway-card gateway-card-ideallab">
                     <div class="gateway-brand gateway-brand-ideallab">
                         <div class="gateway-brand-mark gateway-brand-mark-ideallab" aria-hidden="true" style="width:2.75rem; height:2.75rem; border-radius:0.75rem;">
-                            <img src="{{ '/assets/images/il-logo.svg' | relative_url }}" alt="Ideallab" style="width:2.25rem; height:2.25rem; object-fit:contain;">
+                            <img src="{{ '/assets/ideallab-favicon.svg' | relative_url }}" alt="Ideallab" style="width:2.25rem; height:2.25rem; object-fit:contain;">
                         </div>
                         <div class="gateway-brand-copy">
-                            <p class="gateway-brand-kicker" style="color:#8aa8a2;">Ideallab</p>
-                            <p class="gateway-brand-subtitle" style="color:#c8d9d5;">Consulenza software</p>
+                            <p class="gateway-brand-kicker" style="color:#c4944a;">Ideallab</p>
+                            <p class="gateway-brand-subtitle" style="color:#d4c4a8;">Consulenza software</p>
                         </div>
                     </div>
-                    <p class="paragraph-sm" style="color:#c8d9d5; margin:0 0 1rem;">
+                    <p class="paragraph-sm" style="color:#d4c4a8; margin:0 0 1rem;">
                         Software personalizzato per le PMI. Consulenza, sviluppo e soluzioni su misura.
                     </p>
                     <a href="https://ideallab.org/it/" target="_blank" rel="noopener noreferrer"
@@ -133,7 +133,7 @@
 
 <style>
     .gateway-hero-bg {
-        background: linear-gradient(135deg, #f8fffe 0%, #f0f7fa 50%, #fafafa 100%);
+        background: linear-gradient(135deg, #fafafa 0%, #f5f0e8 50%, #fafafa 100%);
         padding: 0 0 4rem;
     }
     .gateway-card {

--- a/_pages/it/_inner_gateway.html
+++ b/_pages/it/_inner_gateway.html
@@ -233,33 +233,36 @@
         transform: translateX(3px);
     }
 
-    /* ---- IDEALLAB: DARK CARD (bottom row) ---- */
+    /* ---- IDEALLAB: AMBER DARK CARD (bottom row) ---- */
     .gateway-card-ideallab {
         background: #0e0e10;
-        border: 2px solid #2e7d88;
-        color: #e0e8e6;
+        border: 2px solid #c4944a;
+        color: #e8ddd0;
     }
     .gateway-card-ideallab:hover {
-        box-shadow: 0 8px 32px rgba(46, 125, 136, 0.3);
+        box-shadow: 0 8px 32px rgba(196, 148, 74, 0.3);
     }
     .gateway-card-ideallab .gateway-brand-kicker {
-        color: #8aa8a2;
+        color: #c4944a;
     }
     .gateway-card-ideallab .gateway-brand-subtitle {
-        color: #c8d9d5;
+        color: #d4c4a8;
     }
     .gateway-card-ideallab .gateway-brand-mark-ideallab {
         background: transparent;
         box-shadow: none;
     }
     .gateway-card-ideallab .gateway-card-cta-ideallab {
-        background: #2e7d88;
-        color: #ffffff;
+        background: #c4944a;
+        color: #0e0e10;
     }
     .gateway-card-ideallab .gateway-card-cta-ideallab:hover {
-        background: #4dd0c4;
+        background: #d4a85a;
         color: #0e0e10;
         transform: translateX(3px);
+    }
+    .gateway-card-ideallab .paragraph-sm {
+        color: #d4c4a8;
     }
 
     /* ---- Shared: brand mark ---- */

--- a/_pages/it/_inner_gateway.html
+++ b/_pages/it/_inner_gateway.html
@@ -233,14 +233,14 @@
         transform: translateX(3px);
     }
 
-    /* ---- IDEALLAB: AMBER DARK CARD (bottom row) ---- */
+    /* ---- IDEALLAB: WARM CHARCOAL CARD (bottom row) ---- */
     .gateway-card-ideallab {
-        background: #0e0e10;
+        background: #1a1610;
         border: 2px solid #c4944a;
         color: #e8ddd0;
     }
     .gateway-card-ideallab:hover {
-        box-shadow: 0 8px 32px rgba(196, 148, 74, 0.3);
+        box-shadow: 0 8px 32px rgba(196, 148, 74, 0.25);
     }
     .gateway-card-ideallab .gateway-brand-kicker {
         color: #c4944a;

--- a/_pages/it/_inner_gateway.html
+++ b/_pages/it/_inner_gateway.html
@@ -7,57 +7,68 @@
         <div class="container mx-auto px-4 sm:px-6 lg:px-8">
             <div class="text-center mt-16 mb-12">
                 <h1 class="page-title" style="font-size:2.5rem;">
-                     <span style="color:#2e7d88;">Ippocra</span>: due ambiti, un approccio
+                     <span style="color:#2e7d88;">Ippocra</span>: il tuo controllo sui dati aziendali
                  </h1>
                 <p class="paragraph-lg mt-4" style="color:#555; max-width:600px; margin-left:auto; margin-right:auto;">
-                    Costruiamo software che si adatta alle persone — che sia per la salute della tua famiglia o per il business della tua impresa.
+                    Costruiamo software che si adatta al tuo business — un'AI locale che gestisce i tuoi documenti, impara il tuo workflow e resta sulla tua macchina.
                 </p>
             </div>
 
-            <!-- Two Cards -->
-            <div class="max-w-4xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-6 mb-16">
-
-                <!-- Card IDEALLAB — DARK CARD -->
-                <div class="gateway-card gateway-card-ideallab">
-                    <div class="gateway-brand gateway-brand-ideallab">
-                        <div class="gateway-brand-mark gateway-brand-mark-ideallab" aria-hidden="true">
+            <!-- ILAI Card — FEATURED DARK CARD -->
+            <div class="max-w-3xl mx-auto mb-16">
+                <div class="gateway-card gateway-card-ilai featured-glow">
+                    <div class="featured-badge">Prodotto Ippocra</div>
+                    <div class="gateway-brand gateway-brand-ilai">
+                        <div class="gateway-brand-mark gateway-brand-mark-ilai" aria-hidden="true">
                             <img src="{{ '/assets/images/il-logo.svg' | relative_url }}" alt="ILAI" style="width:3.25rem; height:3.25rem; object-fit:contain;">
                         </div>
                         <div class="gateway-brand-copy">
-                            <p class="gateway-brand-kicker">Ideallab</p>
-                            <p class="gateway-brand-subtitle">Local AI</p>
+                            <p class="gateway-brand-kicker">ILAI</p>
+                            <p class="gateway-brand-subtitle">Ippocra Local Artificial Intelligence</p>
                         </div>
                     </div>
-                    <h2 class="mt-0" style="font-size:1.75rem; color:#4dd0c4;">
-                        Ideallab
+                    <h2 class="mt-0" style="font-size:2rem; color:#4dd0c4;">
+                        ILAI
                     </h2>
                     <p class="mt-3 paragraph-md" style="color:#c8d9d5;">
-                        Software personalizzato e <strong>ILAI</strong>: Ideallab Local AI per le PMI.
-                        I tuoi dati non escono mai dal tuo controllo.
+                        Il tuo collega AI locale. Tratta documenti riservati, impara il tuo workflow e cresce con la tua azienda.
+                        <strong>Zero cloud, zero lock-in, zero costi nascosti.</strong>
                     </p>
                     <ul class="mt-4 space-y-2" style="text-align:left;">
                         <li style="display:flex; align-items:flex-start; gap:0.5rem;">
                             <i class="fas fa-check-circle" style="color:#4dd0c4; margin-top:4px;"></i>
-                            <span>ILAI: AI locale, zero lock-in, zero cloud</span>
+                            <span><strong>Dati riservati</strong> — restano dentro la tua rete, mai in cloud</span>
                         </li>
                         <li style="display:flex; align-items:flex-start; gap:0.5rem;">
                             <i class="fas fa-check-circle" style="color:#4dd0c4; margin-top:4px;"></i>
-                            <span>Software su misura per il tuo business</span>
+                            <span><strong>Workflow</strong> che migliora nel tempo — non lo sostituisci, lo insegni</span>
                         </li>
                         <li style="display:flex; align-items:flex-start; gap:0.5rem;">
                             <i class="fas fa-check-circle" style="color:#4dd0c4; margin-top:4px;"></i>
-                            <span>Consulenza AI pratica e concreta</span>
+                            <span><strong>Costi prevedibili</strong> — investimento chiaro, nessuna bolletta sorpresa</span>
+                        </li>
+                        <li style="display:flex; align-items:flex-start; gap:0.5rem;">
+                            <i class="fas fa-check-circle" style="color:#4dd0c4; margin-top:4px;"></i>
+                            <span><strong>Asset che cresce</strong> — più lo usi, più diventa un vantaggio competitivo</span>
                         </li>
                     </ul>
-                    <a href="https://ideallab.org/it/" target="_blank" rel="noopener noreferrer"
-                        class="gateway-card-cta gateway-card-cta-ideallab">
-                        Visita Ideallab
+                    <a href="https://ilai.ippocra.com/it/" target="_blank" rel="noopener noreferrer"
+                        class="gateway-card-cta gateway-card-cta-ilai">
+                        Scopri ILAI
                         <i class="fas fa-arrow-right ml-2"></i>
                     </a>
-                    <p class="mt-2 text-xs" style="color:#7a9a95;">ideallab.org</p>
+                    <p class="mt-2 text-xs" style="color:#7a9a95;">ilai.ippocra.com</p>
                 </div>
+            </div>
 
-                <!-- Card IPPO — LIGHT CARD -->
+            <!-- Ideallab one-liner -->
+            <p class="text-center mb-12" style="color:#666; font-size:1.05rem;">
+                Ideallab — software personalizzato per imprese che vogliono crescere.
+                <a href="https://ideallab.org/it/" target="_blank" rel="noopener noreferrer" style="color:#2e7d88; text-decoration:underline;">Scopri di più →</a>
+            </p>
+
+            <!-- Ippo Card — LIGHT CARD -->
+            <div class="max-w-3xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-6 mb-16">
                 <div class="gateway-card gateway-card-ippo">
                     <div class="gateway-brand gateway-brand-ippo">
                         <div class="gateway-brand-mark gateway-brand-mark-ippo" aria-hidden="true">
@@ -95,21 +106,27 @@
                     <p class="mt-2 text-xs" style="color:#888;">ippocra.com/ippo</p>
                 </div>
 
-            </div>
-
-            <!-- Trust badges -->
-            <div class="flex flex-wrap justify-center gap-6 mt-4">
-                <div class="flex items-center gap-2 px-4 py-2 rounded-full border" style="border-color:#2e7d88; color:#2e7d88;">
-                    <i class="fas fa-shield-alt"></i>
-                    <span class="font-semibold text-sm">GDPR Compliant</span>
-                </div>
-                <div class="flex items-center gap-2 px-4 py-2 rounded-full border" style="border-color:#2e7d88; color:#2e7d88;">
-                    <i class="fas fa-lock"></i>
-                    <span class="font-semibold text-sm">Privacy First</span>
-                </div>
-                <div class="flex items-center gap-2 px-4 py-2 rounded-full border" style="border-color:#2e7d88; color:#2e7d88;">
-                    <i class="fas fa-building"></i>
-                    <span class="font-semibold text-sm">Startup Innovativa</span>
+                <!-- Trust badges — moved into their own card -->
+                <div class="gateway-card gateway-card-trust">
+                    <h3 style="font-size:1.1rem; color:#555; margin-bottom:1rem;">Perché Ippocra</h3>
+                    <div class="flex flex-col gap-3">
+                        <div class="flex items-center gap-2">
+                            <i class="fas fa-shield-alt" style="color:#2e7d88;"></i>
+                            <span class="font-semibold text-sm" style="color:#333;">GDPR Compliant</span>
+                        </div>
+                        <div class="flex items-center gap-2">
+                            <i class="fas fa-lock" style="color:#2e7d88;"></i>
+                            <span class="font-semibold text-sm" style="color:#333;">Privacy First</span>
+                        </div>
+                        <div class="flex items-center gap-2">
+                            <i class="fas fa-building" style="color:#2e7d88;"></i>
+                            <span class="font-semibold text-sm" style="color:#333;">Startup Innovativa</span>
+                        </div>
+                    </div>
+                    <div style="margin-top:1.5rem; padding-top:1rem; border-top:1px solid #e0e7e6;">
+                        <p style="font-size:0.85rem; color:#888; margin:0;">Contattaci</p>
+                        <a href="mailto:info@ippocra.com" style="color:#2e7d88; text-decoration:none; font-weight:600;">info@ippocra.com</a>
+                    </div>
                 </div>
             </div>
         </div>
@@ -128,41 +145,61 @@
         transition: transform 0.2s, box-shadow 0.2s;
         display: flex;
         flex-direction: column;
+        position: relative;
     }
     .gateway-card:hover {
         transform: translateY(-2px);
     }
 
-    /* ---- IDEALLAB: DARK CARD (black bg, teal text) ---- */
-    .gateway-card-ideallab {
+    /* ---- Featured badge for ILAI ---- */
+    .featured-badge {
+        display: inline-block;
+        background: #2e7d88;
+        color: #ffffff;
+        font-size: 0.7rem;
+        font-weight: 700;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        padding: 4px 14px;
+        border-radius: 999px;
+        margin-bottom: 1rem;
+    }
+
+    /* ---- Featured glow effect ---- */
+    .featured-glow {
+        box-shadow: 0 4px 20px rgba(46, 125, 136, 0.12);
+    }
+    .featured-glow:hover {
+        box-shadow: 0 8px 40px rgba(46, 125, 136, 0.35);
+    }
+
+    /* ---- ILAI: FEATURED DARK CARD ---- */
+    .gateway-card-ilai {
         background: #0e0e10;
         border: 2px solid #2e7d88;
         color: #e0e8e6;
     }
-    .gateway-card-ideallab:hover {
-        box-shadow: 0 8px 32px rgba(46, 125, 136, 0.3);
-    }
-    .gateway-card-ideallab .gateway-brand-kicker {
+    .gateway-card-ilai .gateway-brand-kicker {
         color: #8aa8a2;
     }
-    .gateway-card-ideallab .gateway-brand-subtitle {
+    .gateway-card-ilai .gateway-brand-subtitle {
         color: #c8d9d5;
     }
-    .gateway-card-ideallab .gateway-brand-mark-ideallab {
+    .gateway-card-ilai .gateway-brand-mark-ilai {
         background: transparent;
         box-shadow: none;
     }
-    .gateway-card-ideallab .gateway-card-cta-ideallab {
+    .gateway-card-ilai .gateway-card-cta-ilai {
         background: #2e7d88;
         color: #ffffff;
     }
-    .gateway-card-ideallab .gateway-card-cta-ideallab:hover {
+    .gateway-card-ilai .gateway-card-cta-ilai:hover {
         background: #4dd0c4;
         color: #0e0e10;
         transform: translateX(3px);
     }
 
-    /* ---- IPPO: LIGHT CARD (white bg, teal accents) ---- */
+    /* ---- IPPO: LIGHT CARD ---- */
     .gateway-card-ippo {
         background: #ffffff;
         border: 2px solid #e0e7e6;
@@ -186,7 +223,18 @@
         transform: translateX(3px);
     }
 
-    /* ---- SHARED: brand mark ---- */
+    /* ---- Trust card ---- */
+    .gateway-card-trust {
+        background: #ffffff;
+        border: 2px solid #e0e7e6;
+        box-shadow: 0 2px 8px rgba(46, 125, 136, 0.06);
+    }
+    .gateway-card-trust:hover {
+        box-shadow: 0 8px 24px rgba(46, 125, 136, 0.12);
+        border-color: #2e7d88;
+    }
+
+    /* ---- Shared: brand mark ---- */
     .gateway-brand {
         display: flex;
         align-items: center;

--- a/_pages/it/home.md
+++ b/_pages/it/home.md
@@ -2,12 +2,12 @@
 layout: landing_page
 lang: it
 permalink: /
-title: "Ippocra — due ambiti, un approccio"
+title: "Ippocra — il tuo controllo sui dati aziendali"
 redirect_from:
     - /customers
 markdown: false
-description: "Ippocra: due attività complementari, una squadra. Ideallab — software personalizzato e AI locale per le imprese. Ippo — piattaforma sanitaria per le famiglie."
-keywords: "Ippocra, Ideallab, ILAI, AI locale, software personalizzato, Ippo, salute digitale, documentazione sanitaria famiglia"
+description: "Ippocra: costruiamo AI locale per le imprese (ILAI) che resta sulla tua macchina, e Ippo — piattaforma sanitaria per le famiglie."
+keywords: "Ippocra, ILAI, AI locale, Ippo, salute digitale, documentazione sanitaria famiglia, dati aziendali, intelligenza artificiale locale"
 ---
 
 {% include_relative _inner_gateway.html %}

--- a/assets/ideallab-favicon.svg
+++ b/assets/ideallab-favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Ideallab favicon">
+  <rect width="512" height="512" rx="96" fill="#2e7d88"/>
+  <text x="222" y="320" text-anchor="middle" font-family="DejaVu Serif, Georgia, serif" font-weight="700" font-size="250" fill="#ffffff">i</text>
+  <text x="332" y="314" text-anchor="middle" font-family="DejaVu Serif, Georgia, serif" font-weight="700" font-size="290" fill="#ffffff">D</text>
+</svg>


### PR DESCRIPTION
## Changes

### 1. ILAI card is now the prominent featured product
- Renamed from "Ideallab" → **"ILAI — Ippocra Local Artificial Intelligence"**
- Added **"Prodotto Ippocra"** badge to signal it's the flagship product
- Added featured glow effect (hover shadow) for visual prominence
- Headline bumped to 2rem (from 1.75rem)
- CTA changed from "Visita Ideallab" → **"Scopri ILAI"** linking to `ilai.ippocra.com`

### 2. Updated messaging (pulled from ILAI site)
- Description reframed around ILAI as the core product
- Bullet points updated:
  - **Dati riservati** — restano dentro la tua rete, mai in cloud
  - **Workflow** che migliora nel tempo — non lo sostituisci, lo insegni
  - **Costi prevedibili** — investimento chiaro, nessuna bolletta sorpresa
  - **Asset che cresce** — più lo usi, più diventa un vantaggio competitivo

### 3. Hero headline — no health mention
- Before: *"Ippocra: due ambiti, un approccio"*
- After: *"Ippocra: il tuo controllo sui dati aziendali"* / *"Ippocra: own your company data, your own AI"*

### 4. Ideallab as simple one-liner
- Added a single text line below the ILAI card: *"Ideallab — software personalizzato per imprese che vogliono crescere."*
- Links to `ideallab.org` for brand reach purposes
- Not a card — just a subtle line for reach

### 5. Restructured layout
- ILAI card is now full-width and centered (featured)
- Ippo and trust badges sit below in a two-column layout
- Trust badges moved from inline pills to a clean dedicated card

### 6. SEO metadata updated
- Updated `<title>`, `<description>`, and `<keywords>` for both IT and EN versions
- Removed "Ideallab" from primary keywords, added ILAI/company data terms
