### PR TITLE
chore: align Greek homepage with EN/IT, rewrite About pages, update AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,14 @@ There is no test suite or linter configured in this project.
 
 ## Architecture
 
-This is a **Jekyll 4.4** marketing website for Ippocra (a health records platform), using the **Minimal Mistakes** theme with the "mint" skin. It deploys automatically to GitHub Pages on every push to `main`.
+This is a **Jekyll 4.4** marketing website for Ippocra, using the **Minimal Mistakes** theme with the "mint" skin. It deploys automatically to GitHub Pages on every push to `main`.
+
+### Brand structure
+
+- **Ippocra** — the parent company. Main site at ippocra.com.
+- **ILAI** (Ippocra Local Artificial Intelligence) — flagship product. Hosted at `ilai.ippocra.com` (separate repo).
+- **Ippo** — digital health platform for families. Sub-page on ippocra.com (`/ippo`).
+- **Ideallab** — custom software & AI consultancy for SMEs. Separate site at `ideallab.org`.
 
 ### Multilingual (3 languages)
 
@@ -33,9 +40,56 @@ The site uses `jekyll-polyglot` to serve Italian (default), English, and Greek. 
 
 ### Page construction
 
-Pages are thin Markdown files (in `_pages/`) that include large HTML partials from `_includes/` (e.g., `_inner_home.html`, `_inner_pricing.html`). The real page content lives in those includes, not in the Markdown files.
+Pages are thin Markdown files (in `_pages/`) that include large HTML partials from `_includes/` (e.g., `_inner_gateway.html`, `_inner_ippo.html`). The real page content lives in those includes, not in the Markdown files.
 
-Layouts hierarchy: `default.html` (base with nav/footer) → `landing_page.html` or `single.html`.
+**Routing conventions:**
+- Root page (`/`, `/_pages/it/home.md`) → includes `_inner_gateway.html` (gateway/homepage)
+- `/ippo` pages (`/_pages/it/ippo.md`) → includes `_inner_ippo.html`, sets `nav_type: ippo` for masthead variant
+- `/about` pages (`/_pages/it/chi-siamo.md` for IT, `_pages/it/about.md` for EN/EL) → includes `_inner_about.html`
+- Blog: `_posts/it/` and `_posts/en/` for Italian and English posts (Greek has no blog)
+
+### Layouts
+
+- `default.html` — base layout with nav/footer
+- `landing_page.html` — full-width landing layout (used for gateway/homepage, ippo, about)
+- `single.html` — blog post layout
+
+**Masthead variants** (three different navbars):
+- `_includes/masthead.html` — default navbar (used for blog, about, etc.)
+- `_includes/masthead-gateway.html` — gateway/homepage navbar (no "Chi Siamo" link, simpler)
+- `_includes/masthead-ippo.html` — ippo subpage navbar (highlighted Ippo link)
+
+### Homepage (Gateway)
+
+The homepage (`_inner_gateway.html`) follows a strict product hierarchy:
+
+1. **ILAI** — flagship product. Featured as a full-width dark card with "Prodotto Ippocra" badge, glow hover effect, and 4 bullet points from ILAI messaging.
+2. **Three-card row** — below the featured ILAI: compact ILAI card (dark) | Ippo card (light/white) | Ideallab card (dark sepia/warm). Each card has logo, one-line description, and CTA button.
+3. **Background** — warm neutral gradient (`#fafafa → #f5f0e8 → #fafafa`) for consistent contrast across all card colors.
+
+**CSS class conventions:**
+- Featured ILAI: `.gateway-card-ilai` (full-width, dark, glow)
+- Compact ILAI (bottom row): `.gateway-card-ilai-compact` (dark, same colors)
+- Ippo: `.gateway-card-ippo` (light/white background)
+- Ideallab: `.gateway-card-ideallab` (dark sepia `#3b2e20`, amber accents)
+- All share: `.gateway-card`, `.gateway-brand`, `.gateway-brand-mark`, `.gateway-card-cta`
+- Small CTA variant: `.gateway-card-cta-sm` for compact cards
+- Featured badge: `.featured-badge` (pill, teal bg)
+- Glow effect: `.featured-glow` (hover shadow)
+
+**Hero headline rules:**
+- IT: "Ippocra: il tuo controllo sui dati aziendali"
+- EN: "Ippocra: own your company data, your own AI"
+- EL: "Ippocra: il tuo controllo sui dati aziendali, la tua AI"
+- **Must NEVER mention health.** Focus on company data ownership, local AI, cost control.
+
+### About page
+
+The about page (`_inner_about.html`) uses a clean, corporate, high-level structure — no product specifics, no team photos:
+- Hero headline with vision statement
+- Two paragraphs of corporate philosophy (data ownership, transparency, user-first technology)
+- "Innovation with Agency" as the signature quote (always in English, same in all languages)
+- CTA section at bottom
 
 ### Styling
 
@@ -48,3 +102,25 @@ Custom styles live in `_sass/` (SCSS modules: `_palette.scss`, `_typography.scss
 - `_data/locales.yml` — language code → locale mappings
 - `Gemfile` — Ruby gems (jekyll, minimal-mistakes, polyglot, paginate-v2, minifier, redirect-from, tailwindcss)
 - `package.json` — Node deps (FontAwesome only)
+
+### Assets
+
+- `assets/images/il-logo.svg` — ILAI logo (SVG)
+- `assets/images/ippo-mascot.png` — Ippo mascot (PNG, ~87KB)
+- `assets/ideallab-favicon.svg` — Ideallab favicon/logo (SVG)
+
+### Navigation
+
+The main nav is defined in `_data/navigation.yml`. Currently includes Blog and "Chi Siamo". The gateway homepage uses `masthead-gateway.html` which omits "Chi Siamo" for a cleaner hero-focused experience. The ippo subpage uses `masthead-ippo.html` with the Ippo link highlighted.
+
+### Deployment
+
+GitHub Actions workflow pushes to `ippocra.github.io` repo for GitHub Pages deployment. Every push to `main` triggers an automatic rebuild and deploy.
+
+### Common pitfalls
+
+- **Footer carries stale branding** — Always update footers after adapting pages. They often contain old logos, names, and links not present in page content.
+- **Broken relative paths after page moves** — When pages move, CSS/JS references break. Fix all `../` paths after copy.
+- **Three card backgrounds must be distinct** — ILAI dark (`#0e0e10`), Ippo light (`#ffffff`), Ideallab sepia (`#3b2e20`). Never use variations of black for the third card.
+- **Gateway background** — Use warm neutral gradient (`#fafafa → #f5f0e8 → #fafafa`), NOT a brand-colored gradient. A teal gradient competes with both dark and light cards.
+- **ILAI headline must never mention health** — Focus on company data ownership, local AI, cost control.

--- a/_pages/el/_inner_about.html
+++ b/_pages/el/_inner_about.html
@@ -37,9 +37,8 @@
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
                 <div class="mt-12 max-w-2xl mx-auto leading-relaxed">
                     <p class="paragraph-md" style="color:#3b9ba8;">
-                        Based in Ancona, Italy — far from the noise of global tech hubs, but close to what matters.
-                        We choose this not for the aesthetics, but because it reinforces our core belief:
-                        technology should serve the people who use it, not the platforms that own it.
+                        Based in Ancona, Italy. We work and connect with the world at a European and global scale —
+                        local by choice, international by nature.
                         If you'd like to know more, reach out at <a href="mailto:info@ippocra.com" style="color:#3b9ba8; text-decoration:underline;">info@ippocra.com</a>.
                     </p>
                 </div>

--- a/_pages/el/_inner_about.html
+++ b/_pages/el/_inner_about.html
@@ -2,105 +2,32 @@
 
 <body>
     <main class="main-content">
-        <!-- Hero / Mission Section -->
+        <!-- Hero Section -->
         <section id="hero" class="section-blank">
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
                 <div class="animate-fadeInUp" style="opacity:0;">
                     <h1 class="page-title">
-                        Πίσω από το Ippocra υπάρχουν άνθρωποι.<br class="hidden sm:inline">
-                        Πριν από την τεχνολογία.
+                        Η πιο αξιόπιστη τεχνολογία είναι αυτή που δεν ζητάει τίποτα από εσένα.<br class="hidden sm:inline">
+                        Να επιστρέφει στις ανθρώπους τον έλεγχο των δικών τους δεδομένων.
                     </h1>
-                    <p class="mt-4 paragraph-lg" style="color:#3b9ba8;">
-                        Μια ομάδα με έναν απλό στόχο: να κάνει τη διαχείριση της υγείας πιο εύκολη για τους ανθρώπους.
-                    </p>
                     <div class="mt-6 max-w-2xl mx-auto leading-relaxed">
                         <p class="paragraph-md">
-                            Το Ippocra γεννήθηκε από ένα προσωπικό πρόβλημα: διάσπαρτα έγγραφα υγείας, δύσκολο να τα βρεις
-                            και αδύνατο να τα μοιραστείς όταν τα χρειάζεσαι πραγματικά.
-                            Η δουλειά μας είναι να μετατρέψουμε αυτή την πολυπλοκότητα σε κάτι σαφές, ασφαλές και ανθρώπινο.
+                            Το Ippocra πιστεύει ότι οι πληροφορίες που μας ορίζουν — είτε είναι ιατρικά αρχεία,
+                            επιχειρηματικές διαδικασίες ή απλές στιγμές της ζωής — ανήκουν σε όποιον τις δημιούργησε.
+                            Δεν τις αντιμετωπίζουμε ως προϊόντα. Τις προστατεύουμε ως ευθύνη.
+                        </p>
+                    </div>
+                    <div class="mt-6 max-w-2xl mx-auto leading-relaxed">
+                        <p class="paragraph-md">
+                            Κατασκευάζουμε λογισμικό και τεχνητή νοημοσύνη που εργάζεται για όσους το χρησιμοποιούν,
+                            όχι για όσους το κατέχουν. Διαφανείς τεχνολογικές επιλογές, προβλέψιμο κόστος,
+                            μηδενική εξάρτηση από εξωτερικές πλατφόρμες. Γιατί όταν τα δεδομένα παραμένουν δικά σου,
+                            η τεχνολογία παύει να είναι ρίσκο και γίνεται πλεονέκτημα.
                         </p>
                     </div>
                     <p class="mt-8 paragraph-lg paragraph-bold" style="color:#3b9ba8;">
-                        "Λιγότερη πολυπλοκότητα. Περισσότερος έλεγχος. Περισσότερη εμπιστοσύνη."
+                        "Innovation with Agency"
                     </p>
-                </div>
-            </div>
-         </section>
-
-        <!-- Two Pillars Section -->
-        <section id="pillars" class="section-transparent">
-            <div class="section-container">
-                <h2 class="mt-0 section-title text-center">
-                    Οι δραστηριότητές μας
-                </h2>
-                <p class="mt-7 text-center paragraph-md paragraph-bold">
-                    Το Ippocra δρα σε δύο συμπληρωματικούς άξονες: την ψηφιακή υγεία για οικογένειες και τη συμβουλευτική AI για επιχειρήσεις.
-                </p>
-
-                <div class="mt-10 grid grid-cols-1 md:grid-cols-2 gap-8">
-                    <!-- Ippo Card -->
-                    <div class="bg-white border border-gray-200 rounded-2xl shadow-sm px-8 py-10 text-center">
-                        <h3 class="text-xl font-bold text-gray-900 mb-3" style="color:#3b9ba8;">Ippo</h3>
-                        <p class="paragraph-md text-gray-700 mb-6">
-                            Η πλατφόρμα υγείας μας για οικογένειες. Οργανώστε, βρείτε και μοιραστείτε ιατρικά αρχεία με ασφάλεια.
-                        </p>
-                        <a href="{{ '/el/ippo' | relative_url }}" class="secondary-button">Ανακαλύψτε το Ippo</a>
-                    </div>
-
-                    <!-- Ideallab Card -->
-                    <div class="bg-white border border-gray-200 rounded-2xl shadow-sm px-8 py-10 text-center">
-                        <h3 class="text-xl font-bold text-gray-900 mb-3" style="color:#3b9ba8;">Ideallab</h3>
-                        <p class="paragraph-md text-gray-700 mb-6">
-                            Η διέλευση λογισμικού και συμβουλευτικής AI μας για ΜΜΕ. Κατασκευάζουμε λύσεις που προσαρμόζονται στην επιχείρησή σας.
-                        </p>
-                        <a href="https://ideallab.org" target="_blank" rel="noopener noreferrer" class="secondary-button">Επισκεφθείτε το Ideallab →</a>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- Team Section -->
-        <section id="team" class="section-transparent">
-            <div class="section-container">
-                <h2 class="mt-0 section-title text-center">
-                    Η ομάδα
-                </h2>
-                <p class="mt-7 text-center paragraph-md paragraph-bold">
-                    Μια ομάδα με εμπειρία στην υγεία και τον ψηφιακό τομέα, εστιασμένη στην εμπιστοσύνη, την απλότητα και την ασφάλεια.
-                </p>
-
-                <div class="mt-10 grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8">
-                    <!-- Card 1 -->
-                    <div class="bg-white border border-gray-200 rounded-2xl shadow-sm px-5 lg:px-6 py-10 text-center overflow-hidden">
-                        <div class="w-36 h-36 lg:w-40 lg:h-40 rounded-full bg-gray-200 mx-auto mb-6">
-                            <img src="{{ 'assets/images/people/MM.webp' | relative_url }}" alt="Michele Mattioni" class="w-full h-full object-cover rounded-full">
-                        </div>
-                        <h3 class="text-xl font-bold text-gray-900 mb-1">Michele Mattioni</h3>
-                        <p class="text-sm font-semibold mb-4" style="color:#3b9ba8;">Founder</p>
-                        <p class="paragraph-md text-gray-700">
-                            Ιδρυτής του Ippocra, που δρα σε δύο συμπληρωματικούς άξονες:
-                            την πλατφόρμα Ippo για την ψηφιακή υγεία των οικογενειών και το Ideallab,
-                            τη συμβουλευτική λογισμικού και AI για επιχειρήσεις.
-                            Καθοδηγεί το προϊόν Ippo ξεκινώντας από πραγματικά σενάρια χρήσης,
-                            με εστίαση στη σαφήνεια, την ιδιωτικότητα και τη χρησιμότητα,
-                            ενώ η τεχνική όραση ενισχύεται επίσης από τον κόσμο του Ideallab.
-                        </p>
-                    </div>
-
-                    <!-- Card 2 -->
-                    <div class="bg-white border border-gray-200 rounded-2xl shadow-sm px-5 lg:px-6 py-10 text-center overflow-hidden">
-                        <div class="w-36 h-36 lg:w-40 lg:h-40 rounded-full bg-gray-200 mx-auto mb-6">
-                            <img src="{{ 'assets/images/people/MK.webp' | relative_url }}" alt="Myrto Kostadima" class="w-full h-full object-cover rounded-full">
-                        </div>
-                        <h3 class="text-xl font-bold text-gray-900 mb-1">Myrto Kostadima</h3>
-                        <p class="text-sm font-semibold mb-4" style="color:#3b9ba8;">Co-founder</p>
-                        <p class="paragraph-md text-gray-700">
-                            Συνιδρύτρια: ενώνει τους δύο προσώπους του Ippocra, Ippo και Ideallab.
-                            Συντονίζει τις λειτουργίες και τις επιχειρηματικές διαδικασίες και στις δύο δραστηριότητες,
-                            διασφαλίζοντας ότι αναπτύσσονται με δομημένο τρόπο,
-                            επιτρέποντας στην ομάδα να επικεντρωθεί στο προϊόν και την καινοτομία.
-                        </p>
-                    </div>
                 </div>
             </div>
         </section>
@@ -112,7 +39,7 @@
                     Θέλετε να μάθετε περισσότερα;
                 </h2>
                 <p class="paragraph-lg animate-fadeIn delay-300">
-                    Επικοινωνήστε μαζί μας στο info@ippocra.com ή ακολουθήστε μας στα μέσα κοινωνικής δικτύωσης για να μένετε ενημερωμένοι.
+                    Επικοινωνήστε μαζί μας στο info@ippocra.com
                 </p>
                 <a href="https://app.ippocra.com/register" target="_blank" rel="noopener noreferrer"
                     class="main-color-button hero-button">

--- a/_pages/el/_inner_about.html
+++ b/_pages/el/_inner_about.html
@@ -35,13 +35,13 @@
         <!-- Contact Section -->
         <section id="contact" class="section-transparent">
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
-                <div class="mt-12 max-w-2xl mx-auto">
-                    <p class="paragraph-lg" style="color:#3b9ba8; font-weight:700;">
-                        Ancona, Italy
+                <div class="mt-12 max-w-2xl mx-auto leading-relaxed">
+                    <p class="paragraph-md" style="color:#3b9ba8;">
+                        Based in Ancona, Italy — far from the noise of global tech hubs, but close to what matters.
+                        We choose this not for the aesthetics, but because it reinforces our core belief:
+                        technology should serve the people who use it, not the platforms that own it.
+                        If you'd like to know more, reach out at <a href="mailto:info@ippocra.com" style="color:#3b9ba8; text-decoration:underline;">info@ippocra.com</a>.
                     </p>
-                    <a href="mailto:info@ippocra.com" class="paragraph-md" style="color:#3b9ba8; text-decoration:none; border-bottom: 1px solid #3b9ba8;">
-                        info@ippocra.com
-                    </a>
                 </div>
             </div>
         </section>

--- a/_pages/el/_inner_about.html
+++ b/_pages/el/_inner_about.html
@@ -32,15 +32,26 @@
             </div>
         </section>
 
+        <!-- Contact Section -->
+        <section id="contact" class="section-transparent">
+            <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
+                <div class="mt-12 max-w-2xl mx-auto">
+                    <p class="paragraph-lg" style="color:#3b9ba8; font-weight:700;">
+                        Ancona, Italy
+                    </p>
+                    <a href="mailto:info@ippocra.com" class="paragraph-md" style="color:#3b9ba8; text-decoration:none; border-bottom: 1px solid #3b9ba8;">
+                        info@ippocra.com
+                    </a>
+                </div>
+            </div>
+        </section>
+
         <!-- CTA Section -->
         <section id="cta" class="section-main-hard-gradient">
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
                 <h2 class="mt-0 page-title animate-fadeIn delay-100">
                     Θέλετε να μάθετε περισσότερα;
                 </h2>
-                <p class="paragraph-lg animate-fadeIn delay-300">
-                    Επικοινωνήστε μαζί μας στο info@ippocra.com
-                </p>
                 <a href="https://app.ippocra.com/register" target="_blank" rel="noopener noreferrer"
                     class="main-color-button hero-button">
                     Ξεκινήστε δωρεάν

--- a/_pages/el/_inner_about.html
+++ b/_pages/el/_inner_about.html
@@ -37,9 +37,9 @@
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
                 <div class="mt-12 max-w-2xl mx-auto leading-relaxed">
                     <p class="paragraph-md" style="color:#3b9ba8;">
-                        Based in Ancona, Italy. We work and connect with the world at a European and global scale —
-                        local by choice, international by nature.
-                        If you'd like to know more, reach out at <a href="mailto:info@ippocra.com" style="color:#3b9ba8; text-decoration:underline;">info@ippocra.com</a>.
+                        Βασιζόμαστε στην Ανκώνα, Ιταλία. Εργαζόμαστε και συνδεόμαστε με τον κόσμο σε ευρωπαϊκή και παγκόσμια κλίμακα —
+                        τοπική επιλογή, διεθνής φύση.
+                        Αν θέλετε να μάθετε περισσότερα, επικοινωνήστε στο <a href="mailto:info@ippocra.com" style="color:#3b9ba8; text-decoration:underline;">info@ippocra.com</a>.
                     </p>
                 </div>
             </div>

--- a/_pages/el/_inner_gateway.html
+++ b/_pages/el/_inner_gateway.html
@@ -7,110 +7,124 @@
         <div class="container mx-auto px-4 sm:px-6 lg:px-8">
             <div class="text-center mt-16 mb-12">
                 <h1 class="page-title" style="font-size:2.5rem;">
-                     <span style="color:#2e7d88;">Ippocra</span>: δύο τομείς, μία προσέγγιση
+                     <span style="color:#2e7d88;">Ippocra</span>: il tuo controllo sui dati aziendali, la tua AI
                  </h1>
                 <p class="paragraph-lg mt-4" style="color:#555; max-width:600px; margin-left:auto; margin-right:auto;">
-                    Κατασκευάζουμε λογισμικό που προσαρμόζεται στους ανθρώπους — είτε για την υγεία της οικογένειάς σας, είτε για την επιχείρησή σας.
+                    Costruiamo software che si adatta al tuo business — un'AI locale che gestisce i tuoi documenti, impara il tuo workflow e resta sulla tua macchina.
                 </p>
             </div>
 
-            <!-- Two Cards -->
-            <div class="max-w-4xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-6 mb-16">
-
-                <!-- Card IDEALLAB — DARK CARD -->
-                <div class="gateway-card gateway-card-ideallab">
-                    <div class="gateway-brand gateway-brand-ideallab">
-                        <div class="gateway-brand-mark gateway-brand-mark-ideallab" aria-hidden="true">
+            <!-- ILAI Card — FEATURED DARK CARD -->
+            <div class="max-w-3xl mx-auto mb-16">
+                <div class="gateway-card gateway-card-ilai featured-glow">
+                    <div class="featured-badge">Prodotto Ippocra</div>
+                    <div class="gateway-brand gateway-brand-ilai">
+                        <div class="gateway-brand-mark gateway-brand-mark-ilai" aria-hidden="true">
                             <img src="{{ '/assets/images/il-logo.svg' | relative_url }}" alt="ILAI" style="width:3.25rem; height:3.25rem; object-fit:contain;">
                         </div>
                         <div class="gateway-brand-copy">
-                            <p class="gateway-brand-kicker">Ideallab</p>
-                            <p class="gateway-brand-subtitle">Local AI</p>
+                            <p class="gateway-brand-kicker">ILAI</p>
+                            <p class="gateway-brand-subtitle">Ippocra Local Artificial Intelligence</p>
                         </div>
                     </div>
-                    <h2 class="mt-0" style="font-size:1.75rem; color:#4dd0c4;">
-                        Ideallab
+                    <h2 class="mt-0" style="font-size:2rem; color:#4dd0c4;">
+                        ILAI
                     </h2>
                     <p class="mt-3 paragraph-md" style="color:#c8d9d5;">
-                        Προσαρμοσμένο λογισμικό και <strong>ILAI</strong>: Ideallab Local AI για ΜΜΕ.
-                        Τα δεδομένα σας δεν φεύγουν ποτέ από τον έλεγχό σας.
+                        Il tuo collega AI locale. Tratta documenti riservati, impara il tuo workflow e cresce con la tua azienda.
+                        <strong>Zero cloud, zero lock-in, zero costi nascosti.</strong>
                     </p>
                     <ul class="mt-4 space-y-2" style="text-align:left;">
                         <li style="display:flex; align-items:flex-start; gap:0.5rem;">
                             <i class="fas fa-check-circle" style="color:#4dd0c4; margin-top:4px;"></i>
-                            <span>ILAI: τοπική ΤΝ, μηδενικό lock-in, μηδενικό cloud</span>
+                            <span><strong>Dati riservati</strong> — restano dentro la tua rete, mai in cloud</span>
                         </li>
                         <li style="display:flex; align-items:flex-start; gap:0.5rem;">
                             <i class="fas fa-check-circle" style="color:#4dd0c4; margin-top:4px;"></i>
-                            <span>Προσαρμοσμένο λογισμικό για την επιχείρησή σας</span>
+                            <span><strong>Workflow</strong> che migliora nel tempo — non lo sostituisci, lo migliori</span>
                         </li>
                         <li style="display:flex; align-items:flex-start; gap:0.5rem;">
                             <i class="fas fa-check-circle" style="color:#4dd0c4; margin-top:4px;"></i>
-                            <span>Πρακτική συμβουλευτική ΤΝ</span>
+                            <span><strong>Costi prevedibili</strong> — investimento chiaro, nessuna bolletta sorpresa</span>
+                        </li>
+                        <li style="display:flex; align-items:flex-start; gap:0.5rem;">
+                            <i class="fas fa-check-circle" style="color:#4dd0c4; margin-top:4px;"></i>
+                            <span><strong>Asset che cresce</strong> — più lo usi, più diventa un vantaggio competitivo</span>
                         </li>
                     </ul>
-                    <a href="https://ideallab.org/el/" target="_blank" rel="noopener noreferrer"
-                        class="gateway-card-cta gateway-card-cta-ideallab">
-                        Επισκεφθείτε το Ideallab
+                    <a href="https://ilai.ippocra.com/el/" target="_blank" rel="noopener noreferrer"
+                        class="gateway-card-cta gateway-card-cta-ilai">
+                        Scopri ILAI
                         <i class="fas fa-arrow-right ml-2"></i>
                     </a>
-                    <p class="mt-2 text-xs" style="color:#7a9a95;">ideallab.org</p>
+                    <p class="mt-2 text-xs" style="color:#7a9a95;">ilai.ippocra.com</p>
+                </div>
+            </div>
+
+            <!-- Three-card row: ILAI · Ippo · Ideallab -->
+            <p class="text-center mb-6" style="color:#888; font-size:0.9rem; text-transform:uppercase; letter-spacing:0.08em; font-weight:600;">
+                I nostri prodotti
+            </p>
+            <div class="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-6 mb-16">
+
+                <!-- Compact ILAI card -->
+                <div class="gateway-card gateway-card-ilai-compact">
+                    <div class="gateway-brand gateway-brand-ilai-compact">
+                        <div class="gateway-brand-mark gateway-brand-mark-ilai" aria-hidden="true" style="width:2.75rem; height:2.75rem; border-radius:0.75rem;">
+                            <img src="{{ '/assets/images/il-logo.svg' | relative_url }}" alt="ILAI" style="width:2.25rem; height:2.25rem; object-fit:contain;">
+                        </div>
+                        <div class="gateway-brand-copy">
+                            <p class="gateway-brand-kicker" style="color:#8aa8a2;">ILAI</p>
+                        </div>
+                    </div>
+                    <p class="paragraph-sm" style="color:#c8d9d5; margin:0 0 1rem;">
+                        AI locale per le imprese. Dati riservati, zero lock-in, zero cloud.
+                    </p>
+                    <a href="https://ilai.ippocra.com/el/" target="_blank" rel="noopener noreferrer"
+                        class="gateway-card-cta gateway-card-cta-ilai gateway-card-cta-sm">
+                        Vai a ILAI <i class="fas fa-arrow-right ml-1"></i>
+                    </a>
                 </div>
 
-                <!-- Card IPPO — LIGHT CARD -->
+                <!-- Ippo card -->
                 <div class="gateway-card gateway-card-ippo">
                     <div class="gateway-brand gateway-brand-ippo">
-                        <div class="gateway-brand-mark gateway-brand-mark-ippo" aria-hidden="true">
-                            <img src="{{ '/assets/images/ippo-mascot.png' | relative_url }}" alt="Ippo" style="width:3.5rem; height:auto; border-radius:0.75rem;">
+                        <div class="gateway-brand-mark gateway-brand-mark-ippo" aria-hidden="true" style="width:2.75rem; height:2.75rem; border-radius:0.75rem;">
+                            <img src="{{ '/assets/images/ippo-mascot.png' | relative_url }}" alt="Ippo" style="width:2.75rem; height:2.75rem; object-fit:contain;">
                         </div>
                         <div class="gateway-brand-copy">
                             <p class="gateway-brand-kicker">Ippo</p>
-                            <p class="gateway-brand-subtitle">Health platform</p>
+                            <p class="gateway-brand-subtitle">Salute digitale</p>
                         </div>
                     </div>
-                    <h2 style="font-size:1.75rem; color:#2e7d88;">
-                        Ippo
-                    </h2>
-                    <p class="mt-3 paragraph-md" style="color:#4f5b62;">
-                        Η ψηφιακή πλατφόρμα υγείας για οικογένειες. Οργανώστε, βρείτε και μοιραστείτε ιατρικά έγγραφα με ασφάλεια.
+                    <p class="paragraph-sm" style="color:#4f5b62; margin:0 0 1rem;">
+                        La piattaforma per la salute digitale delle famiglie. Organizza, trova e condividi i referti in modo sicuro.
                     </p>
-                    <ul class="mt-4 space-y-2" style="text-align:left;">
-                        <li style="display:flex; align-items:flex-start; gap:0.5rem;">
-                            <i class="fas fa-check-circle" style="color:#2e7d88; margin-top:4px;"></i>
-                            <span>Όλα τα ιατρικά έγγραφα σε ένα μέρος</span>
-                        </li>
-                        <li style="display:flex; align-items:flex-start; gap:0.5rem;">
-                            <i class="fas fa-check-circle" style="color:#2e7d88; margin-top:4px;"></i>
-                            <span>Έξυπνη αναζήτηση και ιατρικό timeline</span>
-                        </li>
-                        <li style="display:flex; align-items:flex-start; gap:0.5rem;">
-                            <i class="fas fa-check-circle" style="color:#2e7d88; margin-top:4px;"></i>
-                            <span>Ασφαλής κοινοποίηση στους γιατρούς</span>
-                        </li>
-                    </ul>
-                    <a href="/el/ippo" class="gateway-card-cta gateway-card-cta-ippo">
-                        Ανακαλύψτε το Ippo
-                        <i class="fas fa-arrow-right ml-2"></i>
+                    <a href="/el/ippo" class="gateway-card-cta gateway-card-cta-ippo gateway-card-cta-sm">
+                        Vai a Ippo <i class="fas fa-arrow-right ml-1"></i>
                     </a>
-                    <p class="mt-2 text-xs" style="color:#888;">ippocra.com/ippo</p>
                 </div>
 
-            </div>
+                <!-- Ideallab card -->
+                <div class="gateway-card gateway-card-ideallab">
+                    <div class="gateway-brand gateway-brand-ideallab">
+                        <div class="gateway-brand-mark gateway-brand-mark-ideallab" aria-hidden="true" style="width:2.75rem; height:2.75rem; border-radius:0.75rem;">
+                            <img src="{{ '/assets/ideallab-favicon.svg' | relative_url }}" alt="Ideallab" style="width:2.25rem; height:2.25rem; object-fit:contain;">
+                        </div>
+                        <div class="gateway-brand-copy">
+                            <p class="gateway-brand-kicker" style="color:#c4944a;">Ideallab</p>
+                            <p class="gateway-brand-subtitle" style="color:#d4c4a8;">Consulenza software</p>
+                        </div>
+                    </div>
+                    <p class="paragraph-sm" style="color:#d4c4a8; margin:0 0 1rem;">
+                        Software personalizzato per le PMI. Consulenza, sviluppo e soluzioni su misura.
+                    </p>
+                    <a href="https://ideallab.org/el/" target="_blank" rel="noopener noreferrer"
+                        class="gateway-card-cta gateway-card-cta-ideallab gateway-card-cta-sm">
+                        Vai a Ideallab <i class="fas fa-arrow-right ml-1"></i>
+                    </a>
+                </div>
 
-            <!-- Trust badges -->
-            <div class="flex flex-wrap justify-center gap-6 mt-4">
-                <div class="flex items-center gap-2 px-4 py-2 rounded-full border" style="border-color:#2e7d88; color:#2e7d88;">
-                    <i class="fas fa-shield-alt"></i>
-                    <span class="font-semibold text-sm">GDPR Συμμόρφωση</span>
-                </div>
-                <div class="flex items-center gap-2 px-4 py-2 rounded-full border" style="border-color:#2e7d88; color:#2e7d88;">
-                    <i class="fas fa-lock"></i>
-                    <span class="font-semibold text-sm">Απόλυτο απόρρητο</span>
-                </div>
-                <div class="flex items-center gap-2 px-4 py-2 rounded-full border" style="border-color:#2e7d88; color:#2e7d88;">
-                    <i class="fas fa-building"></i>
-                    <span class="font-semibold text-sm">Καινοτόμος Startup</span>
-                </div>
             </div>
         </div>
     </section>
@@ -119,7 +133,7 @@
 
 <style>
     .gateway-hero-bg {
-        background: linear-gradient(135deg, #f8fffe 0%, #f0f7fa 50%, #fafafa 100%);
+        background: linear-gradient(135deg, #fafafa 0%, #f5f0e8 50%, #fafafa 100%);
         padding: 0 0 4rem;
     }
     .gateway-card {
@@ -128,41 +142,74 @@
         transition: transform 0.2s, box-shadow 0.2s;
         display: flex;
         flex-direction: column;
+        position: relative;
     }
     .gateway-card:hover {
         transform: translateY(-2px);
     }
 
-    /* ---- IDEALLAB: DARK CARD (black bg, teal text) ---- */
-    .gateway-card-ideallab {
+    /* ---- Featured badge for ILAI ---- */
+    .featured-badge {
+        display: inline-block;
+        background: #2e7d88;
+        color: #ffffff;
+        font-size: 0.7rem;
+        font-weight: 700;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        padding: 4px 14px;
+        border-radius: 999px;
+        margin-bottom: 1rem;
+    }
+
+    /* ---- Featured glow effect ---- */
+    .featured-glow {
+        box-shadow: 0 4px 20px rgba(46, 125, 136, 0.12);
+    }
+    .featured-glow:hover {
+        box-shadow: 0 8px 40px rgba(46, 125, 136, 0.35);
+    }
+
+    /* ---- ILAI: FEATURED DARK CARD ---- */
+    .gateway-card-ilai {
         background: #0e0e10;
         border: 2px solid #2e7d88;
         color: #e0e8e6;
     }
-    .gateway-card-ideallab:hover {
-        box-shadow: 0 8px 32px rgba(46, 125, 136, 0.3);
-    }
-    .gateway-card-ideallab .gateway-brand-kicker {
+    .gateway-card-ilai .gateway-brand-kicker {
         color: #8aa8a2;
     }
-    .gateway-card-ideallab .gateway-brand-subtitle {
+    .gateway-card-ilai .gateway-brand-subtitle {
         color: #c8d9d5;
     }
-    .gateway-card-ideallab .gateway-brand-mark-ideallab {
+    .gateway-card-ilai .gateway-brand-mark-ilai {
         background: transparent;
         box-shadow: none;
     }
-    .gateway-card-ideallab .gateway-card-cta-ideallab {
+    .gateway-card-ilai .gateway-card-cta-ilai {
         background: #2e7d88;
         color: #ffffff;
     }
-    .gateway-card-ideallab .gateway-card-cta-ideallab:hover {
+    .gateway-card-ilai .gateway-card-cta-ilai:hover {
         background: #4dd0c4;
         color: #0e0e10;
         transform: translateX(3px);
     }
 
-    /* ---- IPPO: LIGHT CARD (white bg, teal accents) ---- */
+    /* ---- Compact ILAI (bottom row) ---- */
+    .gateway-card-ilai-compact {
+        background: #0e0e10;
+        border: 2px solid #2e7d88;
+        color: #e0e8e6;
+    }
+    .gateway-card-ilai-compact:hover {
+        box-shadow: 0 8px 32px rgba(46, 125, 136, 0.3);
+    }
+    .gateway-card-ilai-compact .gateway-brand-kicker {
+        color: #8aa8a2;
+    }
+
+    /* ---- IPPO: LIGHT CARD ---- */
     .gateway-card-ippo {
         background: #ffffff;
         border: 2px solid #e0e7e6;
@@ -186,7 +233,39 @@
         transform: translateX(3px);
     }
 
-    /* ---- SHARED: brand mark ---- */
+    /* ---- IDEALLAB: WARM SEPIA CARD (bottom row) ---- */
+    .gateway-card-ideallab {
+        background: #3b2e20;
+        border: 2px solid #c4944a;
+        color: #e8ddd0;
+    }
+    .gateway-card-ideallab:hover {
+        box-shadow: 0 8px 32px rgba(196, 148, 74, 0.2);
+    }
+    .gateway-card-ideallab .gateway-brand-kicker {
+        color: #c4944a;
+    }
+    .gateway-card-ideallab .gateway-brand-subtitle {
+        color: #d4c4a8;
+    }
+    .gateway-card-ideallab .gateway-brand-mark-ideallab {
+        background: transparent;
+        box-shadow: none;
+    }
+    .gateway-card-ideallab .gateway-card-cta-ideallab {
+        background: #c4944a;
+        color: #0e0e10;
+    }
+    .gateway-card-ideallab .gateway-card-cta-ideallab:hover {
+        background: #d4a85a;
+        color: #0e0e10;
+        transform: translateX(3px);
+    }
+    .gateway-card-ideallab .paragraph-sm {
+        color: #d4c4a8;
+    }
+
+    /* ---- Shared: brand mark ---- */
     .gateway-brand {
         display: flex;
         align-items: center;
@@ -232,6 +311,10 @@
         font-weight: 600;
         text-decoration: none;
         transition: all 0.2s;
+    }
+    .gateway-card-cta-sm {
+        padding: 0.6rem 1.25rem;
+        font-size: 0.9rem;
     }
     .gateway-card-cta:hover {
         text-decoration: none;

--- a/_pages/en/_inner_about.html
+++ b/_pages/en/_inner_about.html
@@ -37,9 +37,8 @@
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
                 <div class="mt-12 max-w-2xl mx-auto leading-relaxed">
                     <p class="paragraph-md" style="color:#3b9ba8;">
-                        Based in Ancona, Italy — far from the noise of global tech hubs, but close to what matters.
-                        We choose this not for the aesthetics, but because it reinforces our core belief:
-                        technology should serve the people who use it, not the platforms that own it.
+                        Based in Ancona, Italy. We work and connect with the world at a European and global scale —
+                        local by choice, international by nature.
                         If you'd like to know more, reach out at <a href="mailto:info@ippocra.com" style="color:#3b9ba8; text-decoration:underline;">info@ippocra.com</a>.
                     </p>
                 </div>

--- a/_pages/en/_inner_about.html
+++ b/_pages/en/_inner_about.html
@@ -35,13 +35,13 @@
         <!-- Contact Section -->
         <section id="contact" class="section-transparent">
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
-                <div class="mt-12 max-w-2xl mx-auto">
-                    <p class="paragraph-lg" style="color:#3b9ba8; font-weight:700;">
-                        Ancona, Italy
+                <div class="mt-12 max-w-2xl mx-auto leading-relaxed">
+                    <p class="paragraph-md" style="color:#3b9ba8;">
+                        Based in Ancona, Italy — far from the noise of global tech hubs, but close to what matters.
+                        We choose this not for the aesthetics, but because it reinforces our core belief:
+                        technology should serve the people who use it, not the platforms that own it.
+                        If you'd like to know more, reach out at <a href="mailto:info@ippocra.com" style="color:#3b9ba8; text-decoration:underline;">info@ippocra.com</a>.
                     </p>
-                    <a href="mailto:info@ippocra.com" class="paragraph-md" style="color:#3b9ba8; text-decoration:none; border-bottom: 1px solid #3b9ba8;">
-                        info@ippocra.com
-                    </a>
                 </div>
             </div>
         </section>

--- a/_pages/en/_inner_about.html
+++ b/_pages/en/_inner_about.html
@@ -32,15 +32,26 @@
             </div>
         </section>
 
+        <!-- Contact Section -->
+        <section id="contact" class="section-transparent">
+            <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
+                <div class="mt-12 max-w-2xl mx-auto">
+                    <p class="paragraph-lg" style="color:#3b9ba8; font-weight:700;">
+                        Ancona, Italy
+                    </p>
+                    <a href="mailto:info@ippocra.com" class="paragraph-md" style="color:#3b9ba8; text-decoration:none; border-bottom: 1px solid #3b9ba8;">
+                        info@ippocra.com
+                    </a>
+                </div>
+            </div>
+        </section>
+
         <!-- CTA Section -->
         <section id="cta" class="section-main-hard-gradient">
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
                 <h2 class="mt-0 page-title animate-fadeIn delay-100">
                     Want to learn more?
                 </h2>
-                <p class="paragraph-lg animate-fadeIn delay-300">
-                    Contact us at info@ippocra.com
-                </p>
                 <a href="https://app.ippocra.com/register" target="_blank" rel="noopener noreferrer"
                     class="main-color-button hero-button">
                     Get started free

--- a/_pages/en/_inner_about.html
+++ b/_pages/en/_inner_about.html
@@ -2,105 +2,32 @@
 
 <body>
     <main class="main-content">
-        <!-- Hero / Mission Section -->
+        <!-- Hero Section -->
         <section id="hero" class="section-blank">
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
                 <div class="animate-fadeInUp" style="opacity:0;">
                     <h1 class="page-title">
-                        Behind Ippocra there are people.<br class="hidden sm:inline">
-                        Before technology.
+                        The most reliable technology is the one that asks nothing of you.<br class="hidden sm:inline">
+                        Returning control of data to the people who generate it.
                     </h1>
-                    <p class="mt-4 paragraph-lg" style="color:#3b9ba8;">
-                        A team with a simple goal: making health more manageable for people.
-                    </p>
                     <div class="mt-6 max-w-2xl mx-auto leading-relaxed">
                         <p class="paragraph-md">
-                            Ippocra was born from a personal problem: scattered health documents, hard to find
-                            and impossible to share when you really need them.
-                            Our job is to turn this complexity into something clear, secure and human.
+                            Ippocra believes that the information that defines us — whether health records,
+                            business processes, or simple moments in life — belongs to whoever created them.
+                            We don't treat them as commodities. We protect them as responsibilities.
+                        </p>
+                    </div>
+                    <div class="mt-6 max-w-2xl mx-auto leading-relaxed">
+                        <p class="paragraph-md">
+                            We build software and artificial intelligence that works for the people who use it,
+                            not for those who own it. Transparent technology choices, predictable costs,
+                            no dependency on external platforms. Because when data stays yours,
+                            technology stops being a risk and becomes an advantage.
                         </p>
                     </div>
                     <p class="mt-8 paragraph-lg paragraph-bold" style="color:#3b9ba8;">
-                        "Less complexity. More control. More trust."
+                        "Innovation with Agency"
                     </p>
-                </div>
-            </div>
-        </section>
-
-        <!-- Two Pillars Section -->
-        <section id="pillars" class="section-transparent">
-            <div class="section-container">
-                <h2 class="mt-0 section-title text-center">
-                    Our activities
-                </h2>
-                <p class="mt-7 text-center paragraph-md paragraph-bold">
-                    Ippocra operates in two complementary directions: digital health for families and AI consultancy for businesses.
-                </p>
-
-                <div class="mt-10 grid grid-cols-1 md:grid-cols-2 gap-8">
-                    <!-- Ippo Card -->
-                    <div class="bg-white border border-gray-200 rounded-2xl shadow-sm px-8 py-10 text-center">
-                        <h3 class="text-xl font-bold text-gray-900 mb-3" style="color:#3b9ba8;">Ippo</h3>
-                        <p class="paragraph-md text-gray-700 mb-6">
-                            Our health platform for families. Organize, find, and securely share medical records.
-                        </p>
-                        <a href="{{ '/en/ippo' | relative_url }}" class="secondary-button">Discover Ippo</a>
-                    </div>
-
-                    <!-- Ideallab Card -->
-                    <div class="bg-white border border-gray-200 rounded-2xl shadow-sm px-8 py-10 text-center">
-                        <h3 class="text-xl font-bold text-gray-900 mb-3" style="color:#3b9ba8;">Ideallab</h3>
-                        <p class="paragraph-md text-gray-700 mb-6">
-                            Our software and AI consultancy for SMEs. We build solutions that adapt to your business.
-                        </p>
-                        <a href="https://ideallab.org" target="_blank" rel="noopener noreferrer" class="secondary-button">Visit Ideallab →</a>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- Team Section -->
-        <section id="team" class="section-transparent">
-            <div class="section-container">
-                <h2 class="mt-0 section-title text-center">
-                    The team
-                </h2>
-                <p class="mt-7 text-center paragraph-md paragraph-bold">
-                    A team with health and digital expertise, focused on trust, simplicity and security.
-                </p>
-
-                <div class="mt-10 grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8">
-                    <!-- Card 1 -->
-                    <div class="bg-white border border-gray-200 rounded-2xl shadow-sm px-5 lg:px-6 py-10 text-center overflow-hidden">
-                        <div class="w-36 h-36 lg:w-40 lg:h-40 rounded-full bg-gray-200 mx-auto mb-6">
-                            <img src="{{ 'assets/images/people/MM.webp' | relative_url }}" alt="Michele Mattioni" class="w-full h-full object-cover rounded-full">
-                        </div>
-                        <h3 class="text-xl font-bold text-gray-900 mb-1">Michele Mattioni</h3>
-                        <p class="text-sm font-semibold mb-4" style="color:#3b9ba8;">Founder</p>
-                        <p class="paragraph-md text-gray-700">
-                            Founder of Ippocra, which operates on two complementary fronts:
-                            the Ippo health platform for families and Ideallab,
-                            software and AI consultancy for businesses.
-                            Leads the Ippo product starting from real use cases,
-                            with a focus on clarity, privacy and usefulness,
-                            while the technical vision is also shaped by the Ideallab world.
-                        </p>
-                    </div>
-
-                    <!-- Card 2 -->
-                    <div class="bg-white border border-gray-200 rounded-2xl shadow-sm px-5 lg:px-6 py-10 text-center overflow-hidden">
-                        <div class="w-36 h-36 lg:w-40 lg:h-40 rounded-full bg-gray-200 mx-auto mb-6">
-                            <img src="{{ 'assets/images/people/MK.webp' | relative_url }}" alt="Myrto Kostadima" class="w-full h-full object-cover rounded-full">
-                        </div>
-                        <h3 class="text-xl font-bold text-gray-900 mb-1">Myrto Kostadima</h3>
-                        <p class="text-sm font-semibold mb-4" style="color:#3b9ba8;">Co-founder</p>
-                        <p class="paragraph-md text-gray-700">
-                            Co-founder: keeps the two faces of Ippocra, Ippo and Ideallab, in sync.
-                            Coordinates operations and business processes across both activities,
-                            ensuring they grow in a structured way,
-                            enabling the team to focus on product and innovation.
-                        </p>
-                    </div>
                 </div>
             </div>
         </section>
@@ -112,7 +39,7 @@
                     Want to learn more?
                 </h2>
                 <p class="paragraph-lg animate-fadeIn delay-300">
-                    Contact us at info@ippocra.com or follow us on social media to stay updated.
+                    Contact us at info@ippocra.com
                 </p>
                 <a href="https://app.ippocra.com/register" target="_blank" rel="noopener noreferrer"
                     class="main-color-button hero-button">

--- a/_pages/it/_inner_about.html
+++ b/_pages/it/_inner_about.html
@@ -32,15 +32,26 @@
             </div>
         </section>
 
+        <!-- Contact Section -->
+        <section id="contact" class="section-transparent">
+            <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
+                <div class="mt-12 max-w-2xl mx-auto">
+                    <p class="paragraph-lg" style="color:#3b9ba8; font-weight:700;">
+                        Ancona, Italy
+                    </p>
+                    <a href="mailto:info@ippocra.com" class="paragraph-md" style="color:#3b9ba8; text-decoration:none; border-bottom: 1px solid #3b9ba8;">
+                        info@ippocra.com
+                    </a>
+                </div>
+            </div>
+        </section>
+
         <!-- CTA Section -->
         <section id="cta" class="section-main-hard-gradient">
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
                 <h2 class="mt-0 page-title animate-fadeIn delay-100">
                     Vuoi saperne di più?
                 </h2>
-                <p class="paragraph-lg animate-fadeIn delay-300">
-                    Contattaci a info@ippocra.com
-                </p>
                 <a href="https://app.ippocra.com/register" target="_blank" rel="noopener noreferrer"
                     class="main-color-button hero-button">
                     Inizia gratis

--- a/_pages/it/_inner_about.html
+++ b/_pages/it/_inner_about.html
@@ -2,104 +2,32 @@
 
 <body>
     <main class="main-content">
-        <!-- Hero / Mission Section -->
+        <!-- Hero Section -->
         <section id="hero" class="section-blank">
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
                 <div class="animate-fadeInUp" style="opacity:0;">
                     <h1 class="page-title">
-                        Dietro Ippocra ci sono persone.<br class="hidden sm:inline">
-                        Prima ancora che tecnologia.
+                        La tecnologia più affidabile è quella che non ti chiede nulla.<br class="hidden sm:inline">
+                        Restituire alle persone il controllo dei propri dati.
                     </h1>
-                    <p class="mt-4 paragraph-lg" style="color:#3b9ba8;">
-                        Un team con un obiettivo semplice: rendere la salute più gestibile per le persone.
-                    </p>
-                    <div class="mt-6 max-w-3xl mx-auto leading-relaxed">
+                    <div class="mt-6 max-w-2xl mx-auto leading-relaxed">
                         <p class="paragraph-md">
-                            Ippocra è la fusione di due visioni:
-                            <strong>Ippo</strong>, la piattaforma sanitaria per le famiglie,
-                            e <strong>Ideallab</strong>, la consulenza software e AI per le imprese.
-                            Siamo nati da un problema personale — documenti sparsi e difficili da condividere —
-                            e abbiamo costruito due attività complementari per risolverlo.
+                            Ippocra crede che le informazioni che ci definiscono — che siano documenti sanitari,
+                            processi aziendali o momenti della vita — appartengano a chi li ha generati.
+                            Non le trattiamo come merce. Le proteggiamo come responsabilità.
+                        </p>
+                    </div>
+                    <div class="mt-6 max-w-2xl mx-auto leading-relaxed">
+                        <p class="paragraph-md">
+                            Costruiamo software e intelligenza artificiale che lavorano per chi li usa,
+                            non per chi li possiede. Scelte tecnologiche trasparenti, costi prevedibili,
+                            nessuna dipendenza da piattaforme esterne. Perché quando i dati restano tuoi,
+                            la tecnologia smette di essere un rischio e diventa un vantaggio.
                         </p>
                     </div>
                     <p class="mt-8 paragraph-lg paragraph-bold" style="color:#3b9ba8;">
-                        "Meno complessità. Più controllo. Più fiducia."
+                        "Innovation with Agency"
                     </p>
-                </div>
-            </div>
-       </section>
-
-        <!-- Two Pillars Section -->
-        <section id="pillars" class="section-transparent">
-            <div class="section-container">
-                <h2 class="mt-0 section-title text-center">
-                    Le nostre attività
-                </h2>
-                <p class="mt-7 text-center paragraph-md paragraph-bold">
-                    Ippocra opera in due direzioni complementari: la salute digitale per le famiglie e la consulenza AI per le imprese.
-                </p>
-
-                <div class="mt-10 grid grid-cols-1 md:grid-cols-2 gap-8">
-                    <!-- Ippo Card -->
-                    <div class="bg-white border border-gray-200 rounded-2xl shadow-sm px-8 py-10 text-center">
-                        <h3 class="text-xl font-bold text-gray-900 mb-3" style="color:#3b9ba8;">Ippo</h3>
-                        <p class="paragraph-md text-gray-700 mb-6">
-                            La nostra piattaforma sanitaria per famiglie e pazienti. Organizza, trova e condividi i referti in modo sicuro.
-                        </p>
-                        <a href="{{ '/ippo' | relative_url }}" class="secondary-button">Scopri Ippo</a>
-                    </div>
-
-                    <!-- Ideallab Card -->
-                    <div class="bg-white border border-gray-200 rounded-2xl shadow-sm px-8 py-10 text-center">
-                        <h3 class="text-xl font-bold text-gray-900 mb-3" style="color:#3b9ba8;">Ideallab</h3>
-                        <p class="paragraph-md text-gray-700 mb-6">
-                            La nostra divisione software e consulenza AI per le imprese. Costruiamo soluzioni che si adattano al tuo business.
-                        </p>
-                        <a href="https://ideallab.org" target="_blank" rel="noopener noreferrer" class="secondary-button">Visita Ideallab →</a>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- Team Section -->
-        <section id="team" class="section-transparent">
-            <div class="section-container">
-                <h2 class="mt-0 section-title text-center">
-                    Il team
-                </h2>
-                <p class="mt-7 text-center paragraph-md paragraph-bold">
-                    Un team con competenze sanitarie e digitali, focalizzato su fiducia, semplicità e sicurezza.
-                </p>
-
-                <div class="mt-10 grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8">
-                    <!-- Card 1 -->
-                    <div class="bg-white border border-gray-200 rounded-2xl shadow-sm px-5 lg:px-6 py-10 text-center overflow-hidden">
-                        <div class="w-36 h-36 lg:w-40 lg:h-40 rounded-full bg-gray-200 mx-auto mb-6">
-                            <img src="{{ 'assets/images/people/MM.webp' | relative_url }}" alt="Michele Mattioni" class="w-full h-full object-cover rounded-full">
-                        </div>
-                        <h3 class="text-xl font-bold text-gray-900 mb-1">Michele Mattioni</h3>
-                        <p class="text-sm font-semibold mb-4" style="color:#3b9ba8;">Founder</p>
-                        <p class="paragraph-md text-gray-700">
-                            Fondatore di Ippocra. Guida lo sviluppo di Ippo, la piattaforma per la salute digitale delle famiglie,
-                            e al tempo stesso alimenta la visione tecnica di Ideallab, la consulenza software e AI.
-                            Il suo approccio parte sempre dai casi d'uso reali,
-                            con un focus su chiarezza, privacy e utilità.
-                        </p>
-                    </div>
-
-                    <!-- Card 2 -->
-                    <div class="bg-white border border-gray-200 rounded-2xl shadow-sm px-5 lg:px-6 py-10 text-center overflow-hidden">
-                        <div class="w-36 h-36 lg:w-40 lg:h-40 rounded-full bg-gray-200 mx-auto mb-6">
-                            <img src="{{ 'assets/images/people/MK.webp' | relative_url }}" alt="Myrto Kostadima" class="w-full h-full object-cover rounded-full">
-                        </div>
-                        <h3 class="text-xl font-bold text-gray-900 mb-1">Myrto Kostadima</h3>
-                        <p class="text-sm font-semibold mb-4" style="color:#3b9ba8;">Co-founder</p>
-                        <p class="paragraph-md text-gray-700">
-                            Co-fondatrice di Ippocra: coordina Ippo e Ideallab come un unico ecosistema.
-                            Trasforma due attività apparentemente distinte in processi fluidi e strutturati,
-                            permettendo al team di concentrarsi su prodotto e innovazione.
-                        </p>
-                    </div>
                 </div>
             </div>
         </section>
@@ -111,7 +39,7 @@
                     Vuoi saperne di più?
                 </h2>
                 <p class="paragraph-lg animate-fadeIn delay-300">
-                    Contattaci a info@ippocra.com o seguici sui social per restare aggiornato.
+                    Contattaci a info@ippocra.com
                 </p>
                 <a href="https://app.ippocra.com/register" target="_blank" rel="noopener noreferrer"
                     class="main-color-button hero-button">

--- a/_pages/it/_inner_about.html
+++ b/_pages/it/_inner_about.html
@@ -35,13 +35,13 @@
         <!-- Contact Section -->
         <section id="contact" class="section-transparent">
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
-                <div class="mt-12 max-w-2xl mx-auto">
-                    <p class="paragraph-lg" style="color:#3b9ba8; font-weight:700;">
-                        Ancona, Italy
+                <div class="mt-12 max-w-2xl mx-auto leading-relaxed">
+                    <p class="paragraph-md" style="color:#3b9ba8;">
+                        Based in Ancona, Italy, at the heart of the Adriatic — far from the noise of global tech hubs,
+                        but close to what matters. We choose this not for the aesthetics, but because it reinforces our core belief:
+                        technology should serve the people who use it, not the platforms that own it.
+                        If you'd like to know more, reach out at <a href="mailto:info@ippocra.com" style="color:#3b9ba8; text-decoration:underline;">info@ippocra.com</a>.
                     </p>
-                    <a href="mailto:info@ippocra.com" class="paragraph-md" style="color:#3b9ba8; text-decoration:none; border-bottom: 1px solid #3b9ba8;">
-                        info@ippocra.com
-                    </a>
                 </div>
             </div>
         </section>

--- a/_pages/it/_inner_about.html
+++ b/_pages/it/_inner_about.html
@@ -37,9 +37,8 @@
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
                 <div class="mt-12 max-w-2xl mx-auto leading-relaxed">
                     <p class="paragraph-md" style="color:#3b9ba8;">
-                        Based in Ancona, Italy, at the heart of the Adriatic — far from the noise of global tech hubs,
-                        but close to what matters. We choose this not for the aesthetics, but because it reinforces our core belief:
-                        technology should serve the people who use it, not the platforms that own it.
+                        Based in Ancona, Italy. We work and connect with the world at a European and global scale —
+                        local by choice, international by nature.
                         If you'd like to know more, reach out at <a href="mailto:info@ippocra.com" style="color:#3b9ba8; text-decoration:underline;">info@ippocra.com</a>.
                     </p>
                 </div>


### PR DESCRIPTION
## Changes

### 1. Greek homepage () — full rewrite
- Now matches IT/EN structure: featured ILAI card + three-card row (ILAI/Ippo/Ideallab)
- Warm sepia background gradient instead of teal
- ILAI featured card with badge, 4 bullet points
- Three compact product cards with distinct styling (dark ILAI, light Ippo, sepia Ideallab)
- Removed old two-card layout (Ideallab + Ippo only)

### 2. About pages () — IT, EN, EL
- Removed team section (no photos, no bios, no people references)
- Removed pillars section (no Ippo/Ideallab split cards)
- New clean corporate vision structure: hero headline → 2 philosophy paragraphs → "Innovation with Agency" quote → CTA
- High-level messaging focused on data ownership, transparency, user-first technology
- No product-specific mentions or "zero cloud" references

### 3. AGENTS.md — comprehensive update
- Brand structure section (Ippocra → ILAI → Ippo → Ideallab)
- Homepage gateway structure (ILAI featured + three-card row, card conventions)
- Masthead variants documented (default, gateway, ippo)
- About page structure documented
- Styling, assets, and pitfall sections expanded

**Files changed:**
-  — full rewrite
-  — rewritten
-  — rewritten
-  — rewritten
-  — expanded from ~50 to ~120 lines