### PR TITLE
feat: translate Greek homepage to Greek

### DIFF
--- a/_pages/el/_inner_gateway.html
+++ b/_pages/el/_inner_gateway.html
@@ -7,17 +7,17 @@
         <div class="container mx-auto px-4 sm:px-6 lg:px-8">
             <div class="text-center mt-16 mb-12">
                 <h1 class="page-title" style="font-size:2.5rem;">
-                     <span style="color:#2e7d88;">Ippocra</span>: il tuo controllo sui dati aziendali, la tua AI
+                     <span style="color:#2e7d88;">Ippocra</span>: το έλεγχο των δεδομένων σου, η δική σου ΤΝ
                  </h1>
                 <p class="paragraph-lg mt-4" style="color:#555; max-width:600px; margin-left:auto; margin-right:auto;">
-                    Costruiamo software che si adatta al tuo business — un'AI locale che gestisce i tuoi documenti, impara il tuo workflow e resta sulla tua macchina.
+                    Φτιάχνουμε λογισμικό που προσαρμόζεται στην επιχείρησή σου — μια τοπική ΤΝ που διαχειρίζεται τα έγγραφά σου, μαθαίνει τη ροή εργασίας σου και μένει στον υπολογιστή σου.
                 </p>
             </div>
 
             <!-- ILAI Card — FEATURED DARK CARD -->
             <div class="max-w-3xl mx-auto mb-16">
                 <div class="gateway-card gateway-card-ilai featured-glow">
-                    <div class="featured-badge">Prodotto Ippocra</div>
+                    <div class="featured-badge">Προϊόν Ippocra</div>
                     <div class="gateway-brand gateway-brand-ilai">
                         <div class="gateway-brand-mark gateway-brand-mark-ilai" aria-hidden="true">
                             <img src="{{ '/assets/images/il-logo.svg' | relative_url }}" alt="ILAI" style="width:3.25rem; height:3.25rem; object-fit:contain;">
@@ -31,30 +31,30 @@
                         ILAI
                     </h2>
                     <p class="mt-3 paragraph-md" style="color:#c8d9d5;">
-                        Il tuo collega AI locale. Tratta documenti riservati, impara il tuo workflow e cresce con la tua azienda.
-                        <strong>Zero cloud, zero lock-in, zero costi nascosti.</strong>
+                        Ο τοπικός σου συνεργάτης ΤΝ. Διαχειρίζεται εμπιστευτικά έγγραφα, μαθαίνει τη ροή εργασίας σου και αναπτύσσεται μαζί με την επιχείρησή σου.
+                        <strong>Μηδέν cloud, μηδέν κλείδωμα, μηδέν κρυφά κόστη.</strong>
                     </p>
                     <ul class="mt-4 space-y-2" style="text-align:left;">
                         <li style="display:flex; align-items:flex-start; gap:0.5rem;">
                             <i class="fas fa-check-circle" style="color:#4dd0c4; margin-top:4px;"></i>
-                            <span><strong>Dati riservati</strong> — restano dentro la tua rete, mai in cloud</span>
+                            <span><strong>Εμπιστευτικά δεδομένα</strong> — μένουν μέσα στο δίκτυό σου, ποτέ στο cloud</span>
                         </li>
                         <li style="display:flex; align-items:flex-start; gap:0.5rem;">
                             <i class="fas fa-check-circle" style="color:#4dd0c4; margin-top:4px;"></i>
-                            <span><strong>Workflow</strong> che migliora nel tempo — non lo sostituisci, lo migliori</span>
+                            <span><strong>Ροή εργασίας</strong> που βελτιώνεται με τον καιρό — δεν την αντικαθιστάς, την αναπτύσσεις</span>
                         </li>
                         <li style="display:flex; align-items:flex-start; gap:0.5rem;">
                             <i class="fas fa-check-circle" style="color:#4dd0c4; margin-top:4px;"></i>
-                            <span><strong>Costi prevedibili</strong> — investimento chiaro, nessuna bolletta sorpresa</span>
+                            <span><strong>Προβλέψιμο κόστος</strong> — σαφής επένδυση, κανένα έκπληκτο λογαριασμό</span>
                         </li>
                         <li style="display:flex; align-items:flex-start; gap:0.5rem;">
                             <i class="fas fa-check-circle" style="color:#4dd0c4; margin-top:4px;"></i>
-                            <span><strong>Asset che cresce</strong> — più lo usi, più diventa un vantaggio competitivo</span>
+                            <span><strong>Στοιχείο που αυξάνει αξία</strong> — όσο το χρησιμοποιείς, τόσο πιο πολύ ανταγωνιστικό πλεονέκτημα</span>
                         </li>
                     </ul>
                     <a href="https://ilai.ippocra.com/el/" target="_blank" rel="noopener noreferrer"
                         class="gateway-card-cta gateway-card-cta-ilai">
-                        Scopri ILAI
+                        Ανακάλυψε ILAI
                         <i class="fas fa-arrow-right ml-2"></i>
                     </a>
                     <p class="mt-2 text-xs" style="color:#7a9a95;">ilai.ippocra.com</p>
@@ -63,7 +63,7 @@
 
             <!-- Three-card row: ILAI · Ippo · Ideallab -->
             <p class="text-center mb-6" style="color:#888; font-size:0.9rem; text-transform:uppercase; letter-spacing:0.08em; font-weight:600;">
-                I nostri prodotti
+                Τα προϊόντα μας
             </p>
             <div class="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-6 mb-16">
 
@@ -78,11 +78,11 @@
                         </div>
                     </div>
                     <p class="paragraph-sm" style="color:#c8d9d5; margin:0 0 1rem;">
-                        AI locale per le imprese. Dati riservati, zero lock-in, zero cloud.
+                        Τοπική ΤΝ για επιχειρήσεις. Εμπιστευτικά δεδομένα, μηδέν κλείδωμα, μηδέν cloud.
                     </p>
                     <a href="https://ilai.ippocra.com/el/" target="_blank" rel="noopener noreferrer"
                         class="gateway-card-cta gateway-card-cta-ilai gateway-card-cta-sm">
-                        Vai a ILAI <i class="fas fa-arrow-right ml-1"></i>
+                        Πηγαίνε στο ILAI <i class="fas fa-arrow-right ml-1"></i>
                     </a>
                 </div>
 
@@ -94,14 +94,14 @@
                         </div>
                         <div class="gateway-brand-copy">
                             <p class="gateway-brand-kicker">Ippo</p>
-                            <p class="gateway-brand-subtitle">Salute digitale</p>
+                            <p class="gateway-brand-subtitle">Ψηφιακή υγεία</p>
                         </div>
                     </div>
                     <p class="paragraph-sm" style="color:#4f5b62; margin:0 0 1rem;">
-                        La piattaforma per la salute digitale delle famiglie. Organizza, trova e condividi i referti in modo sicuro.
+                        Η πλατφόρμα ψηφιακής υγείας για οικογένειες. Οργάνωσε, βρες και μοιράσου ιατρικά αρχεία με ασφάλεια.
                     </p>
                     <a href="/el/ippo" class="gateway-card-cta gateway-card-cta-ippo gateway-card-cta-sm">
-                        Vai a Ippo <i class="fas fa-arrow-right ml-1"></i>
+                        Πηγαίνε στο Ippo <i class="fas fa-arrow-right ml-1"></i>
                     </a>
                 </div>
 
@@ -113,15 +113,15 @@
                         </div>
                         <div class="gateway-brand-copy">
                             <p class="gateway-brand-kicker" style="color:#c4944a;">Ideallab</p>
-                            <p class="gateway-brand-subtitle" style="color:#d4c4a8;">Consulenza software</p>
+                            <p class="gateway-brand-subtitle" style="color:#d4c4a8;">Συμβουλευτική λογισμικού</p>
                         </div>
                     </div>
                     <p class="paragraph-sm" style="color:#d4c4a8; margin:0 0 1rem;">
-                        Software personalizzato per le PMI. Consulenza, sviluppo e soluzioni su misura.
+                        Προσαρμοσμένο λογισμικό για ΜμΕ. Συμβουλευτική, ανάπτυξη και λύσεις on measure.
                     </p>
                     <a href="https://ideallab.org/el/" target="_blank" rel="noopener noreferrer"
                         class="gateway-card-cta gateway-card-cta-ideallab gateway-card-cta-sm">
-                        Vai a Ideallab <i class="fas fa-arrow-right ml-1"></i>
+                        Πηγαίνε στο Ideallab <i class="fas fa-arrow-right ml-1"></i>
                     </a>
                 </div>
 

--- a/_pages/el/home.md
+++ b/_pages/el/home.md
@@ -2,12 +2,12 @@
 layout: landing_page
 lang: el
 permalink: /
-title: "Ippocra — δύο τομείς, μία προσέγγιση"
+title: "Ippocra — το έλεγχο των δεδομένων σου"
 redirect_from:
     - /customers
 markdown: false
-description: "Ippocra: δύο συμπληρωματικές επιχειρήσεις, μία ομάδα. Ideallab — προσαρμοσμένο λογισμικό και τοπική ΤΝ για επιχειρήσεις. Ippo — ψηφιακή πλατφόρμα υγείας για οικογένειες."
-keywords: "Ippocra, Ideallab, ILAI, τοπική ΤΝ, προσαρμοσμένο λογισμικό, Ippo, ψηφιακή υγεία, ιατρικά έγγραφα οικογένειας"
+description: "Ippocra: φτιάχνουμε τοπική τεχνητή νοημοσύνη για επιχειρήσεις (ILAI) που παραμένει στον υπολογιστή σας, και Ippo — ψηφιακή πλατφόρμα υγείας για οικογένειες."
+keywords: "Ippocra, ILAI, τοπική τεχνητή νοημοσύνη, Ippo, ψηφιακή υγεία, οικογενειακά ιατρικά αρχεία, εταιρικά δεδομένα, τοπική τεχνητή νοημοσύνη"
 ---
 
 {% include_relative _inner_gateway.html %}


### PR DESCRIPTION
## Changes

Full Greek translation of the homepage (`_inner_gateway.html`) and homepage metadata (`home.md`):

### Hero section
- Headline: fully Greek translation
- Subheadline paragraph: Greek description of local AI for business

### Featured ILAI card
- Badge: "Προϊόν Ippocra"
- Description paragraph: Greek
- 4 bullet points (Dati riservati → Εμπιστευτικά δεδομένα, etc.): all Greek
- CTA: "Ανακάλυψε ILAI"

### Three-card row
- Section label: "Τα προϊόντα μας"
- Compact ILAI: description + CTA in Greek
- Ippo: subtitle ("Ψηφιακή υγεία"), description, CTA in Greek
- Ideallab: subtitle ("Συμβουλευτική λογισμικού"), description, CTA in Greek

### Metadata (home.md)
- Title, description, and keywords updated to Greek

### Unchanged
- All URLs remain the same (ilai.ippocra.com/el/, ideallab.org/el/, /el/ippo)
- CSS styles untouched
- HTML structure identical to IT/EN
