### PR TITLE
fix: use gateway masthead for blog posts

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,7 @@
   <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}" dir="{% if site.rtl %}rtl{% else %}ltr{% endif %}">
     {% include_cached skip-links.html %}
     {% assign page_url = page.url %}
-    {% if page.categories and page.layout != "landing_page" %}
+   {% if page.categories or page.url contains "/posts/" or page.url == "/posts" %}
       {% include_cached masthead-gateway.html page_url=page_url %}
     {% elsif page.nav_type == "ippo" or page.permalink contains "/ippo" or page.permalink contains "/en/ippo" or page.permalink contains "/el/ippo" %}
       {% include_cached masthead-ippo.html page_url=page_url %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,13 @@
   <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}" dir="{% if site.rtl %}rtl{% else %}ltr{% endif %}">
     {% include_cached skip-links.html %}
     {% assign page_url = page.url %}
-    {% include_cached masthead.html page_url=page_url %}
+    {% if page.categories and page.layout != "landing_page" %}
+      {% include_cached masthead-gateway.html page_url=page_url %}
+    {% elsif page.nav_type == "ippo" or page.permalink contains "/ippo" or page.permalink contains "/en/ippo" or page.permalink contains "/el/ippo" %}
+      {% include_cached masthead-ippo.html page_url=page_url %}
+    {% else %}
+      {% include_cached masthead.html page_url=page_url %}
+    {% endif %}
 
     <div class="initial-content">
       {{ content }}


### PR DESCRIPTION
Fixes #80 — masthead mismatch on blog

**Problem:** Blog posts were using  (product nav with ILAI, Security, Doctors, Business, Pricing links) which didn't match the homepage masthead.

**Fix:** Added conditional logic in  to route blog posts (detected via ) to use  instead.

**Masthead routing after fix:**
- **Blog posts** →  (general nav: ILAI, Ideallab, Ippo, Blog, About)
- **Homepage** →  (unchanged, via )
- **Ippo pages** →  (ippo-specific nav, unchanged)
- **About + other pages** →  (product nav, unchanged)