### PR TITLE
Remove DPO Tommaso Rossi references

### DIFF
--- a/_pages/en/_inner_security.html
+++ b/_pages/en/_inner_security.html
@@ -69,10 +69,10 @@
                             </p>
                         </div>
                         <div class="bg-white border border-gray-200 rounded-2xl shadow-sm px-6 py-6">
-                            <h3 class="text-lg font-bold text-gray-900 mb-2">DPO contact</h3>
+                            <h3 class="text-lg font-bold text-gray-900 mb-2">Privacy Contacts</h3>
                             <p class="paragraph-md text-gray-700">
-                                Our Data Protection Officer can be reached at any time
-                                at <a href="mailto:dpo@ippocra.com" style="color:#3b9ba8; font-weight:600;">dpo@ippocra.com</a>.
+                                For any requests regarding data protection, please contact
+                                <a href="mailto:dpo@ippocra.com" style="color:#3b9ba8; font-weight:600;">dpo@ippocra.com</a>.
                             </p>
                         </div>
                     </div>

--- a/_pages/en/policy.md
+++ b/_pages/en/policy.md
@@ -240,7 +240,7 @@ The DPO must carry out the following tasks:
 * Inform and raise awareness among the data controller or processor, as well as employees, about the obligations of the Regulation;  
 * Cooperate with supervisory authorities and act as a point of contact.
 
-The Company has appointed **DPO Avv. Tommaso Rossi**, with an office in Ancona, Via Baccarani 4, tel. 3403947151, email [t.rossi@rpcstudiolegale.it](mailto:t.rossi@rpcstudiolegale.it).
+For any such requests, contact the company at [info@ippocra.com](mailto:info@ippocra.com).
 
 **4.14. Links to other websites**
 

--- a/_pages/it/_inner_security.html
+++ b/_pages/it/_inner_security.html
@@ -69,10 +69,10 @@
                             </p>
                         </div>
                         <div class="bg-white border border-gray-200 rounded-2xl shadow-sm px-6 py-6">
-                            <h3 class="text-lg font-bold text-gray-900 mb-2">Contatto DPO</h3>
+                            <h3 class="text-lg font-bold text-gray-900 mb-2">Contatti Privacy</h3>
                             <p class="paragraph-md text-gray-700">
-                                Il nostro Data Protection Officer è raggiungibile in qualsiasi momento
-                                all'indirizzo <a href="mailto:dpo@ippocra.com" style="color:#3b9ba8; font-weight:600;">dpo@ippocra.com</a>.
+                                Per ogni richiesta relativa alla protezione dei dati, contattare
+                                <a href="mailto:dpo@ippocra.com" style="color:#3b9ba8; font-weight:600;">dpo@ippocra.com</a>.
                             </p>
                         </div>
                     </div>

--- a/_pages/it/policy.md
+++ b/_pages/it/policy.md
@@ -252,7 +252,7 @@ Il DPO deve eseguire i seguenti compiti:
 * Informare e sensibilizzare il Titolare o il Responsabile nonché i dipendenti riguardo agli obblighi del Regolamento;  
 * Cooperare con le autorità di controllo e fungere da punto di contatto.
 
-La Società ha provveduto alla nomina del **DPO nella persona dell’Avv. Tommaso Rossi**, con studio in Ancona Via Baccarani 4 tel. 3403947151, email [t.rossi@rpcstudiolegale.it](mailto:t.rossi@rpcstudiolegale.it)
+Per ogni richiesta di questo tipo, contattare la società all’email [info@ippocra.com](mailto:info@ippocra.com).
 
 **4.14. Link ad altri siti web**
 


### PR DESCRIPTION
## Changes

Removes references to DPO Tommaso Rossi from privacy policy and security pages (IT + EN). All privacy contacts remain at dpo@ippocra.com.

### Files modified:
- `_pages/it/policy.md` — Section 4.13: replaced DPO appointment line with general contact instruction
- `_pages/en/policy.md` — Section 4.13: replaced DPO appointment line with general contact instruction
- `_pages/it/_inner_security.html` — "Contatto DPO" → "Contatti Privacy" card (still links to dpo@ippocra.com)
- `_pages/en/_inner_security.html` — "DPO contact" → "Privacy Contacts" card (still links to dpo@ippocra.com)